### PR TITLE
add wrapper for imgui PlotLines widget

### DIFF
--- a/Widgets.go
+++ b/Widgets.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/color"
 	"image/draw"
+	"math"
 	"time"
 
 	"github.com/AllenDang/giu/imgui"
@@ -103,6 +104,36 @@ func ButtonV(id string, width, height float32, onClick func()) *ButtonWidget {
 		width:   width * Context.platform.GetContentScale(),
 		height:  height * Context.platform.GetContentScale(),
 		onClick: onClick,
+	}
+}
+
+type PlotLinesWidget struct {
+	label        string
+	values       []float32
+	valuesOffset int
+	overlayText  string
+	scaleMin     float32
+	scaleMax     float32
+	graphSize    imgui.Vec2
+}
+
+func (p *PlotLinesWidget) Build() {
+	imgui.PlotLinesV(p.label, p.values, p.valuesOffset, p.overlayText, p.scaleMin, p.scaleMax, p.graphSize)
+}
+
+func PlotLines(label string, values []float32) *PlotLinesWidget {
+	return PlotLinesV(label, values, 0, "", math.MaxFloat32, math.MaxFloat32, imgui.Vec2{})
+}
+
+func PlotLinesV(label string, values []float32, valuesOffset int, overlayText string, scaleMin float32, scaleMax float32, graphSize imgui.Vec2) *PlotLinesWidget {
+	return &PlotLinesWidget{
+		label:        label,
+		values:       values,
+		valuesOffset: valuesOffset,
+		overlayText:  overlayText,
+		scaleMin:     scaleMin,
+		scaleMax:     scaleMax,
+		graphSize:    graphSize,
 	}
 }
 

--- a/examples/plot/main.go
+++ b/examples/plot/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"math"
+
+	g "github.com/AllenDang/giu"
+	"github.com/AllenDang/giu/imgui"
+)
+
+func loop() {
+	plotdata := make([]float32, 0)
+	x := float32(0)
+	delta := float32(0.01)
+	for len(plotdata) < 1000 {
+		plotdata = append(plotdata, float32(math.Sin(float64(x))))
+		x += delta
+	}
+	g.SingleWindow("hello world", g.Layout{
+		g.Label("Hello world from giu"),
+		g.Label("Simple sin(x) plot:"),
+		g.PlotLines("testplot", plotdata),
+		g.Label("sin(x) plot with overlay text, and size:"),
+		g.PlotLinesV("plot label", plotdata, 0, "overlay text", math.MaxFloat32, math.MaxFloat32, imgui.Vec2{X: 500, Y: 200}),
+	})
+}
+
+func main() {
+	wnd := g.NewMasterWindow("Hello world", 600, 400, g.MasterWindowFlagsNotResizable, nil)
+	wnd.Main(loop)
+}

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/AllenDang/giu v0.0.0-20200507113110-68e30f9c2535 h1:ve90h+X6fBoCh/ZnlpbnEeBVgV7HPf1+WUyCr+WVtRA=
+github.com/AllenDang/giu v0.0.0-20200507113110-68e30f9c2535/go.mod h1:I5APP3KkERnp+ERQVVaGOrUcSrgvt0s2lEh4+ap6SdI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This patch only wraps the PlotLines widget from imgui, but the histogram
and other plotting widgets could be wrapped also.

This also adds an example in examples/plot showing both g.PlotLines()
and g.PlotLinesV().

Future work: the imgui plotting widget is a little limited, it would be
nice for GIU to support a more robust plotting system. This could
perhaps be done from scratch based on a Canvas widget, possibly by
writing a back-end for gonum/plot.