### PR TITLE
Make PlotLinesV consistent with other functions

### DIFF
--- a/Widgets.go
+++ b/Widgets.go
@@ -122,10 +122,10 @@ func (p *PlotLinesWidget) Build() {
 }
 
 func PlotLines(label string, values []float32) *PlotLinesWidget {
-	return PlotLinesV(label, values, 0, "", math.MaxFloat32, math.MaxFloat32, imgui.Vec2{})
+	return PlotLinesV(label, values, 0, "", math.MaxFloat32, math.MaxFloat32, 0, 0)
 }
 
-func PlotLinesV(label string, values []float32, valuesOffset int, overlayText string, scaleMin float32, scaleMax float32, graphSize imgui.Vec2) *PlotLinesWidget {
+func PlotLinesV(label string, values []float32, valuesOffset int, overlayText string, scaleMin, scaleMax, width, height float32) *PlotLinesWidget {
 	return &PlotLinesWidget{
 		label:        label,
 		values:       values,
@@ -133,7 +133,7 @@ func PlotLinesV(label string, values []float32, valuesOffset int, overlayText st
 		overlayText:  overlayText,
 		scaleMin:     scaleMin,
 		scaleMax:     scaleMax,
-		graphSize:    graphSize,
+		graphSize:    imgui.Vec2{X: width, Y: height},
 	}
 }
 

--- a/examples/plot/main.go
+++ b/examples/plot/main.go
@@ -4,7 +4,6 @@ import (
 	"math"
 
 	g "github.com/AllenDang/giu"
-	"github.com/AllenDang/giu/imgui"
 )
 
 func loop() {
@@ -20,7 +19,7 @@ func loop() {
 		g.Label("Simple sin(x) plot:"),
 		g.PlotLines("testplot", plotdata),
 		g.Label("sin(x) plot with overlay text, and size:"),
-		g.PlotLinesV("plot label", plotdata, 0, "overlay text", math.MaxFloat32, math.MaxFloat32, imgui.Vec2{X: 500, Y: 200}),
+		g.PlotLinesV("plot label", plotdata, 0, "overlay text", math.MaxFloat32, math.MaxFloat32, 500, 200),
 	})
 }
 


### PR DESCRIPTION
Rather than requiring the user to import imgui for the Vec2 type, we now
just accept with width and height directly.

I think it's OK to use `imgui.Vec2` internally still, but I can remove the `graphSize` field and replace it with two floats if @AllenDang thinks that would be better. Let me know and I will patch it.