### PR TITLE
ImageButtonV Widget

### DIFF
--- a/Widgets.go
+++ b/Widgets.go
@@ -183,6 +183,40 @@ func ImageButton(texture *Texture, width, height float32, onClick func()) *Image
 	}
 }
 
+type ImageButtonVWidget struct {
+	texture      *Texture
+	width        float32
+	height       float32
+	uv0          image.Point
+	uv1          image.Point
+	framePadding int
+	bgColor      color.RGBA
+	tintColor    color.RGBA
+	onClick      func()
+}
+
+func (i *ImageButtonWidgetV) Build() {
+	if i.texture != nil && i.texture.id != 0 {
+		if imgui.ImageButtonV(i.texture.id, imgui.Vec2{X: i.width, Y: i.height}, ToVec2(i.uv0), ToVec2(i.uv1), i.framePadding, ToVec4Color(i.bgColor), ToVec4Color(i.tintColor)) && i.onClick != nil {
+			i.onClick()
+		}
+	}
+}
+
+func ImageButtonV(texture *Texture, width, height float32, uv0, uv1 image.Point, framePadding int, bgColor, tintColor color.RGBA, onClick func()) *ImageButtonVWidget {
+	return &ImageButtonVWidget{
+		texture:      texture,
+		width:        width * Context.platform.GetContentScale(),
+		height:       height * Context.platform.GetContentScale(),
+		uv0:          uv0,
+		uv1:          uv1,
+		framePadding: framePadding,
+		bgColor:      bgColor,
+		tintColor:    tintColor,
+		onClick:      onClick,
+	}
+}
+
 type CheckboxWidget struct {
 	text     string
 	selected *bool

--- a/Widgets.go
+++ b/Widgets.go
@@ -195,7 +195,7 @@ type ImageButtonVWidget struct {
 	onClick      func()
 }
 
-func (i *ImageButtonWidgetV) Build() {
+func (i *ImageButtonVWidget) Build() {
 	if i.texture != nil && i.texture.id != 0 {
 		if imgui.ImageButtonV(i.texture.id, imgui.Vec2{X: i.width, Y: i.height}, ToVec2(i.uv0), ToVec2(i.uv1), i.framePadding, ToVec4Color(i.bgColor), ToVec4Color(i.tintColor)) && i.onClick != nil {
 			i.onClick()

--- a/Widgets.go
+++ b/Widgets.go
@@ -160,30 +160,6 @@ func (ib *InvisibleButtonWidget) Build() {
 }
 
 type ImageButtonWidget struct {
-	texture *Texture
-	width   float32
-	height  float32
-	onClick func()
-}
-
-func (i *ImageButtonWidget) Build() {
-	if i.texture != nil && i.texture.id != 0 {
-		if imgui.ImageButton(i.texture.id, imgui.Vec2{X: i.width, Y: i.height}) && i.onClick != nil {
-			i.onClick()
-		}
-	}
-}
-
-func ImageButton(texture *Texture, width, height float32, onClick func()) *ImageButtonWidget {
-	return &ImageButtonWidget{
-		texture: texture,
-		width:   width * Context.platform.GetContentScale(),
-		height:  height * Context.platform.GetContentScale(),
-		onClick: onClick,
-	}
-}
-
-type ImageButtonVWidget struct {
 	texture      *Texture
 	width        float32
 	height       float32
@@ -195,7 +171,7 @@ type ImageButtonVWidget struct {
 	onClick      func()
 }
 
-func (i *ImageButtonVWidget) Build() {
+func (i *ImageButtonWidget) Build() {
 	if i.texture != nil && i.texture.id != 0 {
 		if imgui.ImageButtonV(i.texture.id, imgui.Vec2{X: i.width, Y: i.height}, ToVec2(i.uv0), ToVec2(i.uv1), i.framePadding, ToVec4Color(i.bgColor), ToVec4Color(i.tintColor)) && i.onClick != nil {
 			i.onClick()
@@ -203,8 +179,22 @@ func (i *ImageButtonVWidget) Build() {
 	}
 }
 
-func ImageButtonV(texture *Texture, width, height float32, uv0, uv1 image.Point, framePadding int, bgColor, tintColor color.RGBA, onClick func()) *ImageButtonVWidget {
-	return &ImageButtonVWidget{
+func ImageButton(texture *Texture, width, height float32, onClick func()) *ImageButtonWidget {
+	return &ImageButtonWidget{
+		texture:      texture,
+		width:        width * Context.platform.GetContentScale(),
+		height:       height * Context.platform.GetContentScale(),
+		uv0:          image.Point{X: 0, Y: 0},
+		uv1:          image.Point{X: 1, Y: 1},
+		framePadding: -1,
+		bgColor:      color.RGBA{0, 0, 0, 0},
+		tintColor:    color.RGBA{255, 255, 255, 255},
+		onClick:      onClick,
+	}
+}
+
+func ImageButtonV(texture *Texture, width, height float32, uv0, uv1 image.Point, framePadding int, bgColor, tintColor color.RGBA, onClick func()) *ImageButtonWidget {
+	return &ImageButtonWidget{
 		texture:      texture,
 		width:        width * Context.platform.GetContentScale(),
 		height:       height * Context.platform.GetContentScale(),


### PR DESCRIPTION
I require the use of ImageButtonV and have implemented a Widget that uses it.

I have some uncertainly with how I've done it. `ImageButtonVWidget` seems awkward as the type, as no other widgets have a verbose version. Would it make sense to adjust `ImageButtonWidget` to contain all of the fields I have placed in the verbose widget and have the regular widget properly populate these fields (similar to how imgui.ImageButton/imgui.ImageButtonV work)? This would probably fit with the general style better.

Additionally, I am also uncertain about the use of image.Point and color.RGBA but this seemed better than using imgui.Vec2/Vec4 directly (unless I'm mistaken). I've used the ToVec2/ToVec4Color utility functions in Utils.go for converting between these two types.

Using the widget is as below and does feel a bit awkward:

```
g.ImageButtonV(t.texture, float32(t.width), float32(t.height), image.Point{X: 0, Y: 0}, image.Point{X: 1, Y: 1}, 0, color.RGBA{0, 0, 0, 0}, color.RGBA{255, 255, 255, 255}, func() { })
```