### PR TITLE
Canvas.AddImageV and DrawList.AddImageV

### DIFF
--- a/Canvas.go
+++ b/Canvas.go
@@ -114,3 +114,7 @@ func (c *Canvas) PathBezierCurveTo(p1, p2, p3 image.Point, num_segments int) {
 func (c *Canvas) AddImage(texture *Texture, pMin, pMax image.Point) {
 	c.drawlist.AddImage(texture.id, ToVec2(pMin), ToVec2(pMax))
 }
+
+func (c *Canvas) AddImageV(texture *Texture, pMin, pMax image.Point, uvMin, uvMax image.Point, color color.RGBA) {
+	c.drawlist.AddImageV(texture.id, ToVec2(pMin), ToVec2(pMax), ToVec2(uvMin), ToVec2(uvMax), ToVec4Color(color))
+}

--- a/imgui/DrawList.go
+++ b/imgui/DrawList.go
@@ -215,3 +215,12 @@ func (list DrawList) AddImage(textureId TextureID, pMin, pMax Vec2) {
 	pMaxArg, _ := pMax.wrapped()
 	C.iggDrawListAddImage(list.handle(), C.IggTextureID(textureId), pMinArg, pMaxArg)
 }
+
+func (list DrawList) AddImageV(textureId TextureID, pMin, pMax Vec2, uvMin, uvMax Vec2, col Vec4) {
+	c := GetColorU32(col)
+	pMinArg, _ := pMin.wrapped()
+	pMaxArg, _ := pMax.wrapped()
+	uvMinArg, _ := uvMin.wrapped()
+	uvMaxArg, _ := uvMax.wrapped()
+	C.iggDrawListAddImageV(list.handle(), C.IggTextureID(textureId), pMinArg, pMaxArg, uvMinArg, uvMaxArg, C.uint(c))
+}

--- a/imgui/DrawListWrapper.cpp
+++ b/imgui/DrawListWrapper.cpp
@@ -195,3 +195,12 @@ void iggDrawListAddImage(IggDrawList handle, IggTextureID id, IggVec2 *p_min,
   Vec2Wrapper pMaxArg(p_max);
   list->AddImage(ImTextureID(id), *pMinArg, *pMaxArg);
 }
+void iggDrawListAddImageV(IggDrawList handle, IggTextureID id, IggVec2 *p_min,
+                         IggVec2 *p_max, IggVec2 *uv_min, IggVec2 *uv_max, unsigned int color) {
+  ImDrawList *list = reinterpret_cast<ImDrawList *>(handle);
+  Vec2Wrapper pMinArg(p_min);
+  Vec2Wrapper pMaxArg(p_max);
+  Vec2Wrapper uvMinArg(uv_min);
+  Vec2Wrapper uvMaxArg(uv_max);
+  list->AddImage(ImTextureID(id), *pMinArg, *pMaxArg, *uvMinArg, *uvMaxArg, color);
+}

--- a/imgui/DrawListWrapper.h
+++ b/imgui/DrawListWrapper.h
@@ -68,6 +68,10 @@ extern void iggDrawListPathBezierCurveTo(IggDrawList handle, IggVec2 *p1,
                                          int num_segments);
 extern void iggDrawListAddImage(IggDrawList handle, IggTextureID id,
                                 IggVec2 *p_min, IggVec2 *p_max);
+extern void iggDrawListAddImageV(IggDrawList handle, IggTextureID id,
+                                IggVec2 *p_min, IggVec2 *p_max,
+                                IggVec2 *uv_min, IggVec2 *uv_max,
+                                unsigned int color);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I need to draw images with color and alpha modulation, and as such, have implemented the AddImageV func to the Canvas.

I was uncertain if Canvas should have a different AddImage func, such as `AddColoredImage` or otherwise, so I opted to go with a "verbose" version of AddImage.

Let me know if I need to make any changes or if this approach is wrong.