### PR TITLE
IsWindowCollapsed, IsWindowFocused, IsWindowHovered

### DIFF
--- a/Events.go
+++ b/Events.go
@@ -49,3 +49,15 @@ func IsMouseDoubleClicked(button MouseButton) bool {
 func IsWindowAppearing() bool {
 	return imgui.IsWindowAppearing()
 }
+
+func IsWindowCollapsed() bool {
+	return imgui.IsWindowCollapsed()
+}
+
+func IsWindowFocused(flags FocusedFlags) bool {
+	return imgui.IsWindowFocused(int(flags))
+}
+
+func IsWindowHovered(flags HoveredFlags) bool {
+	return imgui.IsWindowHovered(int(flags))
+}

--- a/Flags.go
+++ b/Flags.go
@@ -243,3 +243,45 @@ const (
 	// TreeNodeFlagsCollapsingHeader combines TreeNodeFlagsFramed and TreeNodeFlagsNoAutoOpenOnLog.
 	TreeNodeFlagsCollapsingHeader TreeNodeFlags = TreeNodeFlagsFramed | TreeNodeFlagsNoTreePushOnOpen | TreeNodeFlagsNoAutoOpenOnLog
 )
+
+type FocusedFlags int
+
+const (
+	// FocusedFlagsNone default FocusedFlags = 0
+	FocusedFlagsNone FocusedFlags = 0
+	// FocusedFlagsChildWindows matches if any children of the window is focused
+	FocusedFlagsChildWindows FocusedFlags = 1 << 0
+	// FocusedFlagsRootWindow tests from root window (top most parent of the current hierarchy)
+	FocusedFlagsRootWindow FocusedFlags = 1 << 1
+	// FocusedFlagsAnyWindow matches if any window is focused.
+	FocusedFlagsAnyWindow FocusedFlags = 1 << 2
+	// FocusedFlagsRootAndChildWindows combines FocusedFlagsRootWindow and FocusedFlagsChildWindows.
+	FocusedFlagsRootAndChildWindows = FocusedFlagsRootWindow | FocusedFlagsChildWindows
+)
+
+type HoveredFlags int
+
+const (
+	// HoveredFlagsNone is the default and matches if directly over the item/window, not obstructed by another window, not obstructed by an active popup or modal blocking inputs under them.
+	HoveredFlagsNone HoveredFlags = 0
+	// HoveredFlagsChildWindows is for IsWindowHovered() and matches if any children of the window is hovered
+	HoveredFlagsChildWindows HoveredFlags = 1 << 0
+	// HoveredFlagsRootWindow is for IsWindowHovered() and tests from root window (top most parent of the current hierarchy)
+	HoveredFlagsRootWindow HoveredFlags = 1 << 1
+	// HoveredFlagsAnyWindow is for IsWindowHovered() and matches if any window is hovered
+	HoveredFlagsAnyWindow HoveredFlags = 1 << 2
+	// HoveredFlagsAllowWhenBlockedByPopup matches even if a popup window is normally blocking access to this item/window
+	HoveredFlagsAllowWhenBlockedByPopup HoveredFlags = 1 << 3
+	// HoveredFlagsAllowWhenBlockedByModal matches even if a modal popup window is normally blocking access to this item/window. UNIMPLEMENTED in imgui.
+	//HoveredFlagsAllowWhenBlockedByModal  HoveredFlags   = 1 << 4
+	// HoveredFlagsAllowWhenBlockedByActiveItem matches true even if an active item is blocking access to this item/window. Useful for Drag and Drop patterns.
+	HoveredFlagsAllowWhenBlockedByActiveItem HoveredFlags = 1 << 5
+	// HoveredFlagsAllowWhenOverlapped matches even if the position is obstructed or overlapped by another window
+	HoveredFlagsAllowWhenOverlapped HoveredFlags = 1 << 6
+	// HoveredFlagsAllowWhenDisabled matches even if the item is disabled
+	HoveredFlagsAllowWhenDisabled HoveredFlags = 1 << 7
+	// HoveredFlagsRectOnly combines HoveredFlagsAllowWhenBlockedByPopup, HoveredFlagsAllowWhenBlockedByActiveItem, and HoveredFlagsAllowWhenOverlapped.
+	HoveredFlagsRectOnly HoveredFlags = HoveredFlagsAllowWhenBlockedByPopup | HoveredFlagsAllowWhenBlockedByActiveItem | HoveredFlagsAllowWhenOverlapped
+	// HoveredFlagsRootAndChildWindows combines HoveredFlagsRootWindow and HoveredFlagsChildWindows.
+	HoveredFlagsRootAndChildWindows HoveredFlags = HoveredFlagsRootWindow | HoveredFlagsChildWindows
+)

--- a/imgui/imgui.go
+++ b/imgui/imgui.go
@@ -150,6 +150,18 @@ func IsWindowAppearing() bool {
 	return C.iggIsWindowAppearing() != 0
 }
 
+func IsWindowCollapsed() bool {
+	return C.iggIsWindowCollapsed() != 0
+}
+
+func IsWindowFocused(flags int) bool {
+	return C.iggIsWindowFocused(C.int(flags)) != 0
+}
+
+func IsWindowHovered(flags int) bool {
+	return C.iggIsWindowHovered(C.int(flags)) != 0
+}
+
 // SetNextWindowPosV sets next window position.
 // Call before Begin(). Use pivot=(0.5,0.5) to center on given point, etc.
 func SetNextWindowPosV(pos Vec2, cond Condition, pivot Vec2) {

--- a/imgui/imguiWrapper.cpp
+++ b/imgui/imguiWrapper.cpp
@@ -132,6 +132,21 @@ IggBool iggIsWindowAppearing()
   return ImGui::IsWindowAppearing() ? 1: 0;
 }
 
+IggBool iggIsWindowCollapsed()
+{
+  return ImGui::IsWindowCollapsed() ? 1: 0;
+}
+
+IggBool iggIsWindowFocused(int flags)
+{
+  return ImGui::IsWindowFocused(flags) ? 1: 0;
+}
+
+IggBool iggIsWindowHovered(int flags)
+{
+  return ImGui::IsWindowHovered(flags) ? 1: 0;
+}
+
 void iggSetNextWindowPos(IggVec2 const *pos, int cond, IggVec2 const *pivot)
 {
    Vec2Wrapper posArg(pos);

--- a/imgui/imguiWrapper.h
+++ b/imgui/imguiWrapper.h
@@ -38,6 +38,9 @@ extern "C"
 	extern void iggContentRegionAvail(IggVec2 *size);
 
   extern IggBool iggIsWindowAppearing();
+  extern IggBool iggIsWindowCollapsed();
+  extern IggBool iggIsWindowFocused(int flags);
+  extern IggBool iggIsWindowHovered(int flags);
 
 	extern void iggSetNextWindowPos(IggVec2 const *pos, int cond, IggVec2 const *pivot);
 	extern void iggSetNextWindowSize(IggVec2 const *size, int cond);


### PR DESCRIPTION
I needed to detect if a window was focused and hovered so I implemented the bindings for both IsWindowFocused and IsWindowHovered, as well as IsWindowCollapsed for completeness.

For additional completeness, I have also added all of the hovered and focused flags to Flags.go, as it seemed better than just picking the ones I needed.

To note, one of the applications of this is for a KeyBinds/KeyBind widget that adheres to giu's layout->build style.