### PR TITLE
No extra go routines for MainThread.

### DIFF
--- a/MainThread.go
+++ b/MainThread.go
@@ -1,107 +1,83 @@
 package giu
 
-var callQueue chan func()
-
-func checkRun() {
-	if callQueue == nil {
-		panic("mainthread: did not call Run")
-	}
+type queue struct {
+	items chan []func()
+	empty chan bool
 }
 
-// transferTasks transfers tasks from global `callQueue` to `Run` -specific task queue.
-// The function ends on readable event on `done` e.g. the channel is closed.
-func transferTasks(to chan<- func(), done <-chan struct{}) {
-	var (
-		task  func()   // Current task to transfer or `nil`.
-		tasks []func() // A local queue of tasks to transfer.
-		// tasksCh is going to be assigned either `nil` or `to`. We use the fact that
-		// `select` ignores `nil` channels. So we will assign `nil` here if there is
-		// nothing to send, or `to` in case there's a task to be sent out.
-		tasksCh chan<- func()
-	)
-	for {
-		if task == nil && len(tasks) > 0 {
-			// Pop next task from the task queue.
-			task = tasks[0]
-			copy(tasks[:], tasks[1:])
-			tasks = tasks[:len(tasks)-1]
-			// And setup the task channel for select.
-			tasksCh = to
-		}
-		select {
-		case f := <-callQueue:
-			tasks = append(tasks, f)
-		case tasksCh <- task: // nil-channels are ignored by select.
-			task, tasksCh = nil, nil
-		case <-done:
-			return
-		}
+func newQueue() *queue {
+	q := &queue{
+		items: make(chan []func(), 1),
+		empty: make(chan bool, 1),
 	}
+	q.empty <- true
+	return q
 }
+
+func (q *queue) add(f func()) {
+	var items []func()
+	select {
+	case <-q.empty:
+	case items = <-q.items:
+	}
+	q.items <- append(items, f)
+}
+
+func (q *queue) get(done <-chan struct{}) (func(), bool) {
+	var items []func()
+	select {
+	case <-done:
+		return nil, false
+	case items = <-q.items:
+	}
+	f, n := items[0], copy(items, items[1:])
+	if items = items[:n]; len(items) == 0 {
+		q.empty <- true
+	} else {
+		q.items <- items
+	}
+	return f, true
+}
+
+var callQueue = newQueue()
 
 // Run enables mainthread package functionality. To use mainthread package, put your main function
 // code into the run function (the argument to Run) and simply call Run from the real main function.
 //
 // Run returns when run (argument) function finishes.
 func Run(run func()) {
-	// Note: Initializing global `callQueue`. This is potentially unsafe, as `callQueue` might
-	// have been already initialized.
-	// TODO(yarcat): Decide whether we should panic at this point or do something else.
-	callQueue = make(chan func())
-
-	tasks := make(chan func())
 	done := make(chan struct{})
-	go transferTasks(tasks, done)
-
-	go func() {
-		run()
-		close(done) // `close` broadcasts it to all receivers.
-	}()
-
+	go func() { run(); close(done) }()
 	for {
-		select {
-		case f := <-tasks:
+		if f, ok := callQueue.get(done); ok {
 			f()
-		case <-done:
-			return
+		} else {
+			break
 		}
 	}
 }
 
 // CallNonBlock queues function f on the main thread and returns immediately. Does not wait until f
 // finishes.
-func CallNonBlock(f func()) {
-	checkRun()
-	callQueue <- f
-}
+func CallNonBlock(f func()) { callQueue.add(f) }
 
 // Call queues function f on the main thread and blocks until the function f finishes.
 func Call(f func()) {
-	checkRun()
 	done := make(chan struct{})
-	callQueue <- func() {
-		f()
-		done <- struct{}{}
-	}
+	callQueue.add(func() { f(); done <- struct{}{} })
 	<-done
 }
 
 // CallErr queues function f on the main thread and returns an error returned by f.
 func CallErr(f func() error) error {
-	checkRun()
 	errChan := make(chan error)
-	callQueue <- func() {
-		errChan <- f()
-	}
+	callQueue.add(func() { errChan <- f() })
 	return <-errChan
 }
 
 // CallVal queues function f on the main thread and returns a value returned by f.
 func CallVal(f func() interface{}) interface{} {
-	checkRun()
 	respChan := make(chan interface{})
-	callQueue <- func() {
-		respChan <- f()
-	}
+	callQueue.add(func() { respChan <- f() })
 	return <-respChan
 }


### PR DESCRIPTION
There is no functionality changes, though I find this solution shorter and cleaner. See previous PR #65.

This implementation was inspired by
https://github.com/duffn/gophercon2018#rethinking-classical-concurrency-patterns.

Please let me know if you don't like the lines joined, and I'll split them. Please don't hesitate to reject the PR in case you think it isn't worth the change.