### PR TITLE
Switch to neclepsio gl fork; Change TextureID types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20201101223321-f087fae2c024
 	github.com/go-resty/resty/v2 v2.3.0
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/neclepsio/gl v0.0.0-20200622061412-49996e615224
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/neclepsio/gl v0.0.0-20200622061412-49996e615224 h1:Wfuv5/UeFYV8V4GxIs2vwzvhgOCWi+SeVhW/Bv2GiEI=
+github.com/neclepsio/gl v0.0.0-20200622061412-49996e615224/go.mod h1:MA6x3vxq/OZugk8sLZr3xCoJWd3LINvt+Rk6HAtWGvE=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -41,6 +43,7 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/imgui/RendererOpenGL3.go
+++ b/imgui/RendererOpenGL3.go
@@ -5,9 +5,8 @@ import (
 	"image"
 	"math"
 	"runtime"
-	"unsafe"
 
-	"github.com/go-gl/gl/v3.2-core/gl"
+	"github.com/neclepsio/gl/v3.2-core/gl"
 )
 
 // OpenGL3 implements a renderer based on github.com/go-gl/gl (v3.2-core).
@@ -160,9 +159,9 @@ func (renderer *OpenGL3) Render(displaySize [2]float32, framebufferSize [2]float
 	gl.EnableVertexAttribArray(uint32(renderer.attribLocationUV))
 	gl.EnableVertexAttribArray(uint32(renderer.attribLocationColor))
 	vertexSize, vertexOffsetPos, vertexOffsetUv, vertexOffsetCol := VertexBufferLayout()
-	gl.VertexAttribPointer(uint32(renderer.attribLocationPosition), 2, gl.FLOAT, false, int32(vertexSize), unsafe.Pointer(uintptr(vertexOffsetPos)))
-	gl.VertexAttribPointer(uint32(renderer.attribLocationUV), 2, gl.FLOAT, false, int32(vertexSize), unsafe.Pointer(uintptr(vertexOffsetUv)))
-	gl.VertexAttribPointer(uint32(renderer.attribLocationColor), 4, gl.UNSIGNED_BYTE, true, int32(vertexSize), unsafe.Pointer(uintptr(vertexOffsetCol)))
+	gl.VertexAttribPointerWithOffset(uint32(renderer.attribLocationPosition), 2, gl.FLOAT, false, int32(vertexSize), uintptr(vertexOffsetPos))
+	gl.VertexAttribPointerWithOffset(uint32(renderer.attribLocationUV), 2, gl.FLOAT, false, int32(vertexSize), uintptr(vertexOffsetUv))
+	gl.VertexAttribPointerWithOffset(uint32(renderer.attribLocationColor), 4, gl.UNSIGNED_BYTE, true, int32(vertexSize), uintptr(vertexOffsetCol))
 	indexSize := IndexBufferLayout()
 	drawType := gl.UNSIGNED_SHORT
 	if indexSize == 4 {
@@ -194,7 +193,7 @@ func (renderer *OpenGL3) Render(displaySize [2]float32, framebufferSize [2]float
 				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, renderer.textureMagFilter) // magnification filter
 				clipRect := cmd.ClipRect()
 				gl.Scissor(int32(clipRect.X), int32(fbHeight)-int32(clipRect.W), int32(clipRect.Z-clipRect.X), int32(clipRect.W-clipRect.Y))
-				gl.DrawElements(gl.TRIANGLES, int32(cmd.ElementCount()), uint32(drawType), unsafe.Pointer(indexBufferOffset))
+				gl.DrawElementsWithOffset(gl.TRIANGLES, int32(cmd.ElementCount()), uint32(drawType), uintptr(indexBufferOffset))
 			}
 			indexBufferOffset += uintptr(cmd.ElementCount() * indexSize)
 		}

--- a/imgui/TextureID.go
+++ b/imgui/TextureID.go
@@ -5,7 +5,7 @@ import "C"
 
 // TextureID is a user data to identify a texture.
 //
-// TextureID is a uintptr used to pass renderer-agnostic texture references around until it hits your render function.
+// TextureID is a uint64 used to pass renderer-agnostic texture references around until it hits your render function.
 // imgui knows nothing about what those bits represent, it just passes them around. It is up to you to decide what you want the value to carry!
 //
 // It could be an identifier to your OpenGL texture (cast as uint32), a key to your custom engine material, etc.
@@ -14,11 +14,7 @@ import "C"
 // To display a custom image/texture within an imgui window, you may use functions such as imgui.Image().
 // imgui will generate the geometry and draw calls using the TextureID that you passed and which your renderer can use.
 // It is your responsibility to get textures uploaded to your GPU.
-//
-// Note: Internally, the value is based on a pointer type, so its size is dependent on your architecture.
-// For the most part, this will be 64bits on current systems (in 2018).
-// Beware: This value must never be a Go pointer, because the value escapes the runtime!
-type TextureID uintptr
+type TextureID uint64
 
 func (id TextureID) handle() C.IggTextureID {
 	return C.IggTextureID(id)

--- a/imgui/imconfig.h
+++ b/imgui/imconfig.h
@@ -107,3 +107,5 @@ namespace ImGui
     void MyFunction(const char* name, const MyMatrix44& v);
 }
 */
+#include <stdint.h>
+#define ImTextureID uint64_t

--- a/imgui/imguiWrapperTypes.h
+++ b/imgui/imguiWrapperTypes.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -7,7 +9,7 @@ extern "C"
 
 typedef int IggBool;
 typedef float IggFloat;
-typedef void *IggTextureID;
+typedef uint64_t IggTextureID;
 
 typedef void *IggContext;
 typedef void *IggDrawCmd;


### PR DESCRIPTION
These changes remove the unsafe pointer arithmetic problems, thereby
allowing us to actually run giu-based programs with the "-race" flag.

There are still issues that exist in relation to creating textures,
as is made apparent by running any example with the "-race" flag
enabled. There likely needs to be locking/unlocking on either texture
access or wherever texture creation/access is intended. Ideally one
would set up some sort of channel communication for loading textures
and notifying the render thread that they are ready for use.