### PR TITLE
Add method to convert imgui.Texture to Texture

### DIFF
--- a/Texture.go
+++ b/Texture.go
@@ -38,6 +38,11 @@ func NewTextureFromRgba(rgba *image.RGBA) (*Texture, error) {
 	return nil, errors.New("Unknown error occurred")
 }
 
+// ToTexture converts imgui.TextureID to Texture.
+func ToTexture(textureID imgui.TextureID) *Texture {
+	return &Texture{id: textureID}
+}
+
 func (t *Texture) release() {
 	Update()
 	Call(func() {


### PR DESCRIPTION
This method is required in all cases where you need to pass OpenGL texture  (or raw pointer) to any of Image widget.