### PR TITLE
Change render order for MasterWindow

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -165,12 +165,12 @@ func (w *MasterWindow) render() {
 	r := w.renderer
 
 	p.NewFrame()
-	imgui.NewFrame()
-
-	w.updateFunc()
-
-	imgui.Render()
 	r.PreRender(w.clearColor)
+
+	imgui.NewFrame()
+	w.updateFunc()
+	imgui.Render()
+
 	r.Render(p.DisplaySize(), p.FramebufferSize(), imgui.RenderedDrawData())
 	p.PostRender()
 


### PR DESCRIPTION
Current approach won't work if you have any OpenGL operation outside of a separate Framebuffer. The problem is that `r.PreRender()` clears GL canvas right after `w.updateFunc()` which is actually an application loop. I've changed the order to comply.