### PR TITLE
Fix: imm32 ldflags while building imgui

### DIFF
--- a/imgui/imgui.go
+++ b/imgui/imgui.go
@@ -1,6 +1,7 @@
 package imgui
 
 // #cgo CXXFLAGS: -std=c++11
+// #cgo windows LDFLAGS: -limm32g
 // #include "imguiWrapper.h"
 import "C"
 import (

--- a/imgui/imgui.go
+++ b/imgui/imgui.go
@@ -1,7 +1,7 @@
 package imgui
 
 // #cgo CXXFLAGS: -std=c++11
-// #cgo windows LDFLAGS: -limm32g
+// #cgo windows LDFLAGS: -limm32
 // #include "imguiWrapper.h"
 import "C"
 import (


### PR DESCRIPTION
This solves issue #151 where a C dependency of imgui was missing during the build for windows.

Building this example now works: https://github.com/AllenDang/giu/blob/master/examples/helloworld/helloworld.go

![Screenshot_2021-03-18_160651](https://user-images.githubusercontent.com/246380/111691787-0aa91800-8805-11eb-9425-22ec17b48773.png)
