### PR TITLE
fonts: add gnu-free/FreeSans.ttf for linux

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -67,6 +67,10 @@ func init() {
 		// English fonts
 		registerDefaultFonts([]FontInfo{
 			{
+				fontName: "FreeSans.ttf",
+				size:     15,
+			},
+			{
 				fontName: "FiraCode-Medium",
 				size:     15,
 			},


### PR DESCRIPTION
this fixes #212 
![image](https://user-images.githubusercontent.com/73652197/122344183-c71a9300-cf46-11eb-8e59-07649cc25e2e.png)
Sadly I got some strange issues with google-noto (on my other machine) but I added `FreeSanse.ttf` it doesn't look so bad