### PR TITLE
widgets: replace image.RGBA with image.Image interface:

### DIFF
--- a/Texture.go
+++ b/Texture.go
@@ -2,9 +2,10 @@ package giu
 
 import (
 	"errors"
-	"github.com/faiface/mainthread"
 	"image"
 	"runtime"
+
+	"github.com/faiface/mainthread"
 
 	"github.com/AllenDang/imgui-go"
 )
@@ -21,10 +22,10 @@ type loadImageResult struct {
 // Create new texture from rgba.
 // Note: this function has to be invokded in a go routine.
 // If call this in mainthread will result in stuck.
-func NewTextureFromRgba(rgba *image.RGBA) (*Texture, error) {
+func NewTextureFromRgba(rgba image.Image) (*Texture, error) {
 	Update()
 	result := mainthread.CallVal(func() interface{} {
-		texId, err := Context.renderer.LoadImage(rgba)
+		texId, err := Context.renderer.LoadImage(ImageToRgba(rgba))
 		return &loadImageResult{id: texId, err: err}
 	})
 

--- a/Utils.go
+++ b/Utils.go
@@ -22,13 +22,17 @@ func LoadImage(imgPath string) (*image.RGBA, error) {
 		return nil, err
 	}
 
+	return ImageToRgba(img), nil
+}
+
+func ImageToRgba(img image.Image) *image.RGBA {
 	switch trueImg := img.(type) {
 	case *image.RGBA:
-		return trueImg, nil
+		return trueImg
 	default:
 		rgba := image.NewRGBA(trueImg.Bounds())
 		draw.Draw(rgba, trueImg.Bounds(), trueImg, image.Pt(0, 0), draw.Src)
-		return rgba, nil
+		return rgba
 	}
 }
 

--- a/Widgets.go
+++ b/Widgets.go
@@ -333,23 +333,15 @@ func ImageButton(texture *Texture) *ImageButtonWidget {
 
 type ImageButtonWithRgbaWidget struct {
 	*ImageButtonWidget
-	rgba *image.RGBA
+	rgba image.Image
 	id   string
 }
 
-func ImageButtonWithRgba(rgba *image.RGBA) *ImageButtonWithRgbaWidget {
-	// Generate a unique id from first 100 pix from rgba
-	var pix []uint8
-	if len(rgba.Pix) >= 100 {
-		pix = rgba.Pix[:100]
-	} else {
-		pix = rgba.Pix
-	}
-
+func ImageButtonWithRgba(rgba image.Image) *ImageButtonWithRgbaWidget {
 	return &ImageButtonWithRgbaWidget{
+		id:                GenAutoID("ImageButtonWithRgba_%v"),
 		ImageButtonWidget: ImageButton(nil),
 		rgba:              rgba,
-		id:                fmt.Sprintf("ImageButtonWithRgba_%v", pix),
 	}
 }
 
@@ -801,11 +793,11 @@ type ImageWithRgbaWidget struct {
 	id      string
 	width   float32
 	height  float32
-	rgba    *image.RGBA
+	rgba    image.Image
 	onClick func()
 }
 
-func ImageWithRgba(rgba *image.RGBA) *ImageWithRgbaWidget {
+func ImageWithRgba(rgba image.Image) *ImageWithRgbaWidget {
 	return &ImageWithRgbaWidget{
 		id:     GenAutoID("ImageWithRgba_%v"),
 		width:  100,

--- a/Widgets.go
+++ b/Widgets.go
@@ -339,7 +339,7 @@ type ImageButtonWithRgbaWidget struct {
 
 func ImageButtonWithRgba(rgba image.Image) *ImageButtonWithRgbaWidget {
 	return &ImageButtonWithRgbaWidget{
-		id:                GenAutoID("ImageButtonWithRgba_%v"),
+		id:                GenAutoID("ImageButtonWithRgba"),
 		ImageButtonWidget: ImageButton(nil),
 		rgba:              rgba,
 	}
@@ -799,7 +799,7 @@ type ImageWithRgbaWidget struct {
 
 func ImageWithRgba(rgba image.Image) *ImageWithRgbaWidget {
 	return &ImageWithRgbaWidget{
-		id:     GenAutoID("ImageWithRgba_%v"),
+		id:     GenAutoID("ImageWithRgba"),
 		width:  100,
 		height: 100,
 		rgba:   rgba,


### PR DESCRIPTION
- textures.go: use image.Image instead of image.RGBA in arg to NewTextureFromRGBA
- use autoid for imagebuttonwithrgba
- create ImageToRgba method

it should be easier to use