### PR TITLE
giu: add TextureAtlas

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -25,9 +25,7 @@ const (
 	MasterWindowFlagsTransparent MasterWindowFlags = MasterWindowFlags(imgui.GLFWWindowFlagsTransparent)
 )
 
-var (
-	DontCare int = imgui.GlfwDontCare
-)
+var DontCare int = imgui.GlfwDontCare
 
 type MasterWindow struct {
 	width      int
@@ -177,6 +175,7 @@ func (w *MasterWindow) sizeChange(width, height int) {
 
 func (w *MasterWindow) render() {
 	Context.invalidAllState()
+	invalidTextures()
 
 	rebuildFontAtlas()
 
@@ -194,6 +193,7 @@ func (w *MasterWindow) render() {
 	p.PostRender()
 
 	Context.cleanState()
+	cleanTextures()
 }
 
 // Run the main loop to create new frame, process events and call update ui func.

--- a/TextureAtlas.go
+++ b/TextureAtlas.go
@@ -1,0 +1,106 @@
+package giu
+
+import (
+	"errors"
+	"image"
+	"log"
+	"sync"
+)
+
+var textures = &sync.Map{}
+
+type textureField struct {
+	texture *Texture
+	isValid bool
+	forever bool
+}
+
+type TextureLoader struct {
+	img     *image.RGBA
+	forever bool
+
+	tex *Texture
+}
+
+func AddTexture(img *image.RGBA) *TextureLoader {
+	return &TextureLoader{
+		img: img,
+	}
+}
+
+// Tex could be used to get texture pointer.
+// it will be filled with the texture when Build called
+// NOTE: please remember about intializing tex argument in your code
+// by setting it to &giu.Texture{}, because else it will not be set.
+func (t *TextureLoader) Tex(tex *Texture) *TextureLoader {
+	if tex != nil {
+		t.tex = tex
+	}
+	return t
+}
+
+// Forever if set, the texture will not be lost.
+func (t *TextureLoader) Forever() *TextureLoader {
+	t.forever = true
+	return t
+}
+
+func (t *TextureLoader) Build() {
+	// if already loaded, valid texture
+	if tex, ok := textures.Load(t.img); ok && tex != nil {
+		texture := tex.(*textureField)
+		if texture != nil {
+			*t.tex = *texture.texture
+			texture.isValid = true
+			return
+		}
+	}
+
+	// if not, store it to prevent app from invoking load function
+	// more than 1 time
+	textures.Store(t.img, nil)
+	go func() {
+		if t.img == nil {
+			return
+		}
+
+		texture, err := NewTextureFromRgba(t.img)
+
+		switch {
+		case err != nil:
+			log.Print(err)
+			textures.Delete(t.img)
+		case texture == nil:
+			log.Print(errors.New("giu: texture atlas: loaded texture is nil"))
+			textures.Delete(t.img)
+		}
+
+		textures.Store(t.img, &textureField{texture, true, t.forever})
+	}()
+}
+
+func invalidTextures() {
+	textures.Range(func(_, value interface{}) bool {
+		if value == nil {
+			return true
+		}
+
+		tex := value.(*textureField)
+		tex.isValid = false
+		return true
+	})
+}
+
+func cleanTextures() {
+	textures.Range(func(k, v interface{}) bool {
+		if v == nil {
+			return true
+		}
+
+		if tf := v.(*textureField); !tf.isValid {
+			textures.Delete(k)
+		}
+
+		return true
+	})
+}

--- a/examples/loadimage/loadimage.go
+++ b/examples/loadimage/loadimage.go
@@ -7,10 +7,14 @@ import (
 	_ "image/png"
 	"time"
 
+	"github.com/AllenDang/giu"
 	g "github.com/AllenDang/giu"
 )
 
-var rgba *image.RGBA
+var (
+	rgba    *image.RGBA
+	texture = &giu.Texture{}
+)
 
 func loop() {
 	g.SingleWindow().Layout(
@@ -18,6 +22,9 @@ func loop() {
 		g.ImageWithRgba(rgba).OnClick(func() {
 			fmt.Println("rgba image was clicked")
 		}).Size(200, 100),
+
+		g.AddTexture(rgba).Tex(texture),
+		g.Image(texture),
 
 		g.Label("Display image from file"),
 		g.ImageWithFile("gopher.png").OnClick(func() {


### PR DESCRIPTION
Hi Allen,
I was thinking how to (the most confortable) handle imgui textures.
I wrote the following `TextureAtlas.go` code and hope it might be useful.
texture loader implements giu.Widget. it could be used to load and store imgui textures in a global variable in giu.

the mechanism is similar to the Context.state works. If Forever isn't set and the texture hasn't been restored on frame, it is removed.