### PR TITLE
utils: add CalcTextSizeV

### DIFF
--- a/Utils.go
+++ b/Utils.go
@@ -97,7 +97,7 @@ func GetAvailableRegion() (width, height float32) {
 }
 
 func CalcTextSize(text string) (width, height float32) {
-	return CalcTextSizeV(text, false, 0)
+	return CalcTextSizeV(text, false, -1)
 }
 
 func CalcTextSizeV(text string, hideAfterDoubleHash bool, wrapWidth float32) (w, h float32) {

--- a/Utils.go
+++ b/Utils.go
@@ -97,7 +97,11 @@ func GetAvailableRegion() (width, height float32) {
 }
 
 func CalcTextSize(text string) (width, height float32) {
-	size := imgui.CalcTextSize(text, false, 0)
+	return CalcTextSizeV(text, false, 0)
+}
+
+func CalcTextSizeV(text string, hideAfterDoubleHash bool, wrapWidth float32) (w, h float32) {
+	size := imgui.CalcTextSize(text, hideAfterDoubleHash, wrapWidth)
 	return size.X, size.Y
 }
 


### PR DESCRIPTION
```golang
 	size := imgui.CalcTextSize(text, false, 0)
```

@allenDang why default value of `hideAfterDoubleHash` is  `false`?