### PR TITLE
gitignore: add vim cache files (swp)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# vim cache files
+*.swp
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
hi,
it is a kind of pain when you see n-time :grinning:
```console
 3 files changed, 28 insertions(+)
 create mode 100644 .Layout.go.swp
```