### PR TITLE
breaking: Textures: change the type of NewTextureFromRgba

### DIFF
--- a/Widgets.go
+++ b/Widgets.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"image/draw"
 	"math"
 	"time"
 
@@ -398,12 +397,9 @@ func (i *ImageButtonWithRgbaWidget) Build() {
 	if state == nil {
 		Context.SetState(i.id, &ImageState{})
 
-		go func() {
-			texture, err := NewTextureFromRgba(i.rgba)
-			if err == nil {
-				Context.SetState(i.id, &ImageState{texture: texture})
-			}
-		}()
+		NewTextureFromRgba(i.rgba, func(tex *Texture) {
+			Context.SetState(i.id, &ImageState{texture: tex})
+		})
 	} else {
 		imgState := state.(*ImageState)
 		i.ImageButtonWidget.texture = imgState.texture
@@ -842,12 +838,9 @@ func (i *ImageWithRgbaWidget) Build() {
 		if state == nil {
 			Context.SetState(i.id, &ImageState{})
 
-			go func() {
-				texture, err := NewTextureFromRgba(i.rgba)
-				if err == nil {
-					Context.SetState(i.id, &ImageState{texture: texture})
-				}
-			}()
+			NewTextureFromRgba(i.rgba, func(tex *Texture) {
+				Context.SetState(i.id, &ImageState{texture: tex})
+			})
 		} else {
 			imgState := state.(*ImageState)
 			widget.texture = imgState.texture
@@ -895,12 +888,9 @@ func (i *ImageWithFileWidget) Build() {
 
 		img, err := LoadImage(i.imgPath)
 		if err == nil {
-			go func() {
-				texture, err := NewTextureFromRgba(img)
-				if err == nil {
-					Context.SetState(i.id, &ImageState{texture: texture})
-				}
-			}()
+			NewTextureFromRgba(img, func(tex *Texture) {
+				Context.SetState(i.id, &ImageState{texture: tex})
+			})
 		}
 	} else {
 		imgState := state.(*ImageState)
@@ -1007,20 +997,11 @@ func (i *ImageWithUrlWidget) Build() {
 				return
 			}
 
-			rgba := image.NewRGBA(img.Bounds())
-			draw.Draw(rgba, img.Bounds(), img, image.Point{}, draw.Src)
+			rgba := ImageToRgba(img)
 
-			texture, err := NewTextureFromRgba(rgba)
-			if err != nil {
-				Context.SetState(i.id, &ImageState{failure: true})
-
-				// Trigger onFailure event
-				if i.onFailure != nil {
-					i.onFailure(err)
-				}
-				return
-			}
-			Context.SetState(i.id, &ImageState{loading: false, texture: texture})
+			NewTextureFromRgba(rgba, func(tex *Texture) {
+				Context.SetState(i.id, &ImageState{loading: false, texture: tex})
+			})
 
 			// Trigger onReady event
 			if i.onReady != nil {

--- a/examples/canvas/canvas.go
+++ b/examples/canvas/canvas.go
@@ -7,9 +7,7 @@ import (
 	g "github.com/AllenDang/giu"
 )
 
-var (
-	texture *g.Texture
-)
+var texture *g.Texture
 
 func loop() {
 	g.SingleWindow().Layout(
@@ -57,9 +55,9 @@ func main() {
 	wnd := g.NewMasterWindow("Canvas", 600, 600, g.MasterWindowFlagsNotResizable)
 
 	img, _ := g.LoadImage("gopher.png")
-	go func() {
-		texture, _ = g.NewTextureFromRgba(img)
-	}()
+	g.NewTextureFromRgba(img, func(tex *g.Texture) {
+		texture = tex
+	})
 
 	wnd.Run(loop)
 }

--- a/examples/texturefiltering/texturefiltering.go
+++ b/examples/texturefiltering/texturefiltering.go
@@ -84,10 +84,13 @@ func main() {
 
 	spriteImg, _ := g.LoadImage("gopher-sprite.png")
 	largeImg, _ := g.LoadImage("gopher.png")
-	go func() {
-		spriteTexture, _ = g.NewTextureFromRgba(spriteImg)
-		largeTexture, _ = g.NewTextureFromRgba(largeImg)
-	}()
+
+	g.NewTextureFromRgba(spriteImg, func(tex *g.Texture) {
+		spriteTexture = tex
+	})
+	g.NewTextureFromRgba(largeImg, func(tex *g.Texture) {
+		largeTexture = tex
+	})
 
 	wnd.Run(loop)
 }


### PR DESCRIPTION
because of the issues with loading textures in mainthread it is better to allow the giu to call a callback when it is done with loading the texture.
change type of NewTextureFromRgba: func(imag.Image) (*Texture, error) -> func(image.Image, func(*Texture)).
this should fix #316