### PR TITLE
breaking: CodeEditor(): remove `title` argument.

### DIFF
--- a/CodeEditor.go
+++ b/CodeEditor.go
@@ -30,10 +30,17 @@ type CodeEditorWidget struct {
 	border bool
 }
 
-func CodeEditor(title string) *CodeEditorWidget {
+func CodeEditor() *CodeEditorWidget {
 	return &CodeEditorWidget{
-		title: title,
+		title: GenAutoID("##CodeEditor"),
 	}
+}
+
+// ID allows to manually set editor's ID.
+// It isn't necessary to use it in a normal conditions.
+func (ce *CodeEditorWidget) ID(id string) *CodeEditorWidget {
+	ce.title = id
+	return ce
 }
 
 func (ce *CodeEditorWidget) ShowWhitespaces(s bool) *CodeEditorWidget {

--- a/examples/codeeditor/codeeditor.go
+++ b/examples/codeeditor/codeeditor.go
@@ -49,7 +49,7 @@ func loop() {
 func main() {
 	errMarkers = imgui.NewErrorMarkers()
 
-	editor = g.CodeEditor("Code Editor").
+	editor = g.CodeEditor().
 		ShowWhitespaces(false).
 		TabSize(2).
 		Text("select * from greeting\nwhere date > current_timestamp\norder by date").


### PR DESCRIPTION
fix #334 