### PR TITLE
alignment: refactoirng build method

### DIFF
--- a/Alignment.go
+++ b/Alignment.go
@@ -24,13 +24,8 @@ type AlignmentSetter struct {
 // Align sets widgets alignment.
 // usage: see examples/align
 //
-// FIXME: all widgets will be build twice
-// it means, that if you have e.g. CustomWidget it could do unexpected things.
-// Example:
-// Align(AlignToCenter).To(
-//   Custom(func() { fmt.Println("running custom widget") }),
-// )
-// will print the message two times per frame.
+// FIXME: DONOT put giu widgets inside of CustomWidget function in
+// Align setter. CustomWidgets will be skip in alignment process
 //
 // BUG: DatePickerWidget doesn't work properly
 func Align(at AlignmentType) *AlignmentSetter {
@@ -60,6 +55,13 @@ func (a *AlignmentSetter) Build() {
 	a.layout.Range(func(item Widget) {
 		// if item is inil, just skip it
 		if item == nil {
+			return
+		}
+
+		// exclude some widgets from alignment process
+		switch item.(type) {
+		case *CustomWidget:
+			item.Build()
 			return
 		}
 

--- a/Alignment.go
+++ b/Alignment.go
@@ -56,41 +56,31 @@ func (a *AlignmentSetter) Build() {
 	}
 
 	// WORKAROUND: get widgets widths rendering them with 100% transparency
-	// first save start cursor position
-	startPos := GetCursorPos()
-
-	widgetsWidths := make([]float32, 0)
-
-	// render widgets with 0 alpha and store thems widths
-	imgui.PushStyleVarFloat(imgui.StyleVarID(StyleVarAlpha), 0)
+	// to align them later
 	a.layout.Range(func(item Widget) {
-		var width float32
-		if item != nil {
-			item.Build()
-			size := imgui.GetItemRectSize()
-			width = size.X
-		}
-
-		widgetsWidths = append(widgetsWidths, width)
-	})
-	imgui.PopStyleVar()
-
-	// reset cursor pos
-	SetCursorPos(startPos)
-
-	// ALIGN WIDGETS
-	idx := 0o0
-	a.layout.Range(func(item Widget) {
+		// if item is inil, just skip it
 		if item == nil {
 			return
 		}
 
-		w := widgetsWidths[idx]
+		// save cursor position before rendering
 		currentPos := GetCursorPos()
+
+		// render widget in `dry` mode
+		imgui.PushStyleVarFloat(imgui.StyleVarAlpha, 0)
+		item.Build()
+		imgui.PopStyleVar()
+
+		// save widget's width
+		size := imgui.GetItemRectSize()
+		w := size.X
+
 		availableW, _ := GetAvailableRegion()
+
+		// set cursor position to align the widget
 		switch a.alignType {
 		case AlignLeft:
-			// noop
+			SetCursorPos(currentPos)
 		case AlignCenter:
 			SetCursorPos(image.Pt(int(availableW/2-w/2), int(currentPos.Y)))
 		case AlignRight:
@@ -99,8 +89,7 @@ func (a *AlignmentSetter) Build() {
 			panic(fmt.Sprintf("giu: (*AlignSetter).Build: unknown align type %d", a.alignType))
 		}
 
+		// build aligned widget
 		item.Build()
-
-		idx++
 	})
 }

--- a/examples/align/align.go
+++ b/examples/align/align.go
@@ -5,7 +5,7 @@ import "github.com/AllenDang/giu"
 var text string
 
 func loop() {
-	giu.SingleWindow().Layout(
+	giu.Window("window").Layout(
 		giu.Align(giu.AlignCenter).To(
 			giu.Label("I'm a centered label"),
 			giu.Button("I'm a centered button"),


### PR DESCRIPTION
(*AlignSetter).Build() is much shorter now