### PR TITLE
FOntAtlasProsessor: add space (" ") to preregistered string.

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -20,7 +20,7 @@ var (
 )
 
 const (
-	preRegisterString = "\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+	preRegisterString = " \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 )
 
 // FontInfo represents a the font.


### PR DESCRIPTION
try this code:
```golang
package main

import "github.com/AllenDang/giu"

func loop() {
	giu.SingleWindow().Layout(
		giu.CodeEditor(),
	)
}

func main() {
	wnd := giu.NewMasterWindow("demo", 640, 480, 0)
	wnd.Run(loop)
}
```
![image](https://user-images.githubusercontent.com/73652197/135452901-b32a49f1-acdb-4fe6-9124-d5db201f6a70.png)
