### PR TITLE
Update README.md to fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ func loop() {
 }
 
 func main() {
-	wnd := g.NewMasterWindow("Hello world", 400, 200, g.MasterWindowFlagsNotResizable, nil)
+	wnd := g.NewMasterWindow("Hello world", 400, 200, g.MasterWindowFlagsNotResizable)
 	wnd.Run(loop)
 }
 ```


### PR DESCRIPTION
## Fixed quickstart example wnd function call to remove unneeded-params.

Copying the example code does not work unless that ``` , nil ``` is removed

## Changes 

Original 
```golang
wnd := g.NewMasterWindow("Hello world", 400, 200, g.MasterWindowFlagsNotResizable, nil)
```

New 
```golang
wnd := g.NewMasterWindow("Hello world", 400, 200, g.MasterWindowFlagsNotResizable)
```