### PR TITLE
fix: Remove hard config flag `ConfigFlagEnablePowerSavingMode`

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -57,8 +57,6 @@ func NewMasterWindow(title string, width, height int, flags MasterWindowFlags) *
 
 	io := imgui.CurrentIO()
 
-	io.SetConfigFlags(imgui.ConfigFlagEnablePowerSavingMode)
-
 	// Disable imgui.ini
 	io.SetIniFilename("")
 


### PR DESCRIPTION
Fix: Remove hard config flag `ConfigFlagEnablePowerSavingMode` to fix undesirable behavior in case of window reuse (with some OpenGL code, for example).

### What I'm trying to achieve?
I want to reuse the master window to have a context for the OpenGL application without rewriting all the plumber.

### Which issue I'm facing?
Animation is stale if the mouse is not moving (but I'm power-efficient :P ).

https://user-images.githubusercontent.com/2074733/147962749-e5835616-e301-48b3-a1cb-ac42f52223df.mov

### Root cause
Master window is created with a hardcoded config flag `ConfigFlagEnablePowerSavingMode` that cannot be overridden.

### Fix
Remove the hardcoded flag (😎 I know I'm a boss... #kidding, it's a dumb fix). This fix is a breaking change.

### Alternative fix considered

1. Add variadic configFlag... I'm not against the design but this break the actual design (for example `func NewMasterWindow(title string, width, height int, flags MasterWindowFlags, configFlags ...MasterWindowConfigFlag) *MasterWindow`)
2. Add `ConfigFlagEnablePowerSavingMode` in available `MasterWindowFlags`, but we will have to determine what is a configFlag what is not.

We can also add some tests and set `ConfigFlagEnablePowerSavingMode` as a default to prevent a breaking change. Still, from my point of view, this will be strange in long-term support (the documentation must explicitly describe the default configuration).

Example for case 2:

```go
if len(filterConfigFlag(flags)) == 0 {
  io.SetConfigFlags(imgui.ConfigFlagEnablePowerSavingMode)
}
```

Feedback and guidance appreciated.