### PR TITLE
Set a sane fallback font on Linux.

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -83,6 +83,10 @@ func initFontAtlasProcessor() {
 				fontName: "FiraCode-Medium",
 				size:     defaultFontSize + 1,
 			},
+			{
+				fontName: "sans",
+				size:     defaultFontSize + 1,
+			},
 		})
 	}
 }


### PR DESCRIPTION
By default, `sans` is a general alias for some configured sans-serif font. That guarantees, that at least _some_ font is initialized.

Else, some code relying on initialized default fonts will fail. An example is `example/markdown`