### PR TITLE
Replace resty dependency by standard http library.

### DIFF
--- a/ImageWidgets.go
+++ b/ImageWidgets.go
@@ -321,8 +321,7 @@ func (i *ImageWithURLWidget) Build() {
 
 		go func() {
 			// Load image from url
-			client := &http.Client{}
-			client.Timeout = i.downloadTimeout
+			client := &http.Client{Timeout: i.downloadTimeout}
 			req, err := http.NewRequestWithContext(downloadContext, "GET", i.imgURL, nil)
 			if err != nil {
 				errorFn(err)

--- a/ImageWidgets.go
+++ b/ImageWidgets.go
@@ -1,15 +1,14 @@
 package giu
 
 import (
-	"bytes"
 	ctx "context"
 	"fmt"
 	"image"
 	"image/color"
+	"net/http"
 	"time"
 
 	"github.com/AllenDang/imgui-go"
-	resty "github.com/go-resty/resty/v2"
 )
 
 var _ Widget = &ImageWidget{}
@@ -311,31 +310,35 @@ func (i *ImageWithURLWidget) Build() {
 		downloadContext, cancalFunc := ctx.WithCancel(ctx.Background())
 		Context.SetState(i.id, &imageState{loading: true, cancel: cancalFunc})
 
+		errorFn := func(err error) {
+			Context.SetState(i.id, &imageState{failure: true})
+
+			// Trigger onFailure event
+			if i.onFailure != nil {
+				i.onFailure(err)
+			}
+		}
+
 		go func() {
 			// Load image from url
-			client := resty.New()
-			client.SetTimeout(i.downloadTimeout)
-			resp, err := client.R().SetContext(downloadContext).Get(i.imgURL)
+			client := &http.Client{}
+			client.Timeout = i.downloadTimeout
+			req, err := http.NewRequestWithContext(downloadContext, "GET", i.imgURL, nil)
 			if err != nil {
-				Context.SetState(i.id, &imageState{failure: true})
-
-				// Trigger onFailure event
-				if i.onFailure != nil {
-					i.onFailure(err)
-				}
-
+				errorFn(err)
 				return
 			}
 
-			img, _, err := image.Decode(bytes.NewReader(resp.Body()))
+			resp, err := client.Do(req)
 			if err != nil {
-				Context.SetState(i.id, &imageState{failure: true})
+				errorFn(err)
+				return
+			}
+			defer resp.Body.Close()
 
-				// Trigger onFailure event
-				if i.onFailure != nil {
-					i.onFailure(err)
-				}
-
+			img, _, err := image.Decode(resp.Body)
+			if err != nil {
+				errorFn(err)
 				return
 			}
 

--- a/Markdown.go
+++ b/Markdown.go
@@ -69,8 +69,7 @@ func loadImage(path string) imgui.MarkdownImageData {
 	switch {
 	case strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://"):
 		// Load image from url
-		client := &http.Client{}
-		client.Timeout = 5 * time.Second
+		client := &http.Client{Timeout: 5 * time.Second}
 		resp, respErr := client.Get(path)
 		if respErr != nil {
 			return imgui.MarkdownImageData{}

--- a/Markdown.go
+++ b/Markdown.go
@@ -1,16 +1,14 @@
 package giu
 
 import (
-	"bytes"
-	ctx "context"
 	"image"
 	"image/color"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/AllenDang/imgui-go"
 	"github.com/faiface/mainthread"
-	resty "github.com/go-resty/resty/v2"
 )
 
 // MarkdownWidget implements DearImGui markdown extension
@@ -70,17 +68,16 @@ func loadImage(path string) imgui.MarkdownImageData {
 
 	switch {
 	case strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://"):
-		downloadContext := ctx.Background()
-
 		// Load image from url
-		client := resty.New()
-		client.SetTimeout(5 * time.Second)
-		resp, respErr := client.R().SetContext(downloadContext).Get(path)
+		client := &http.Client{}
+		client.Timeout = 5 * time.Second
+		resp, respErr := client.Get(path)
 		if respErr != nil {
 			return imgui.MarkdownImageData{}
 		}
+		defer resp.Body.Close()
 
-		rgba, _, imgErr := image.Decode(bytes.NewReader(resp.Body()))
+		rgba, _, imgErr := image.Decode(resp.Body)
 		if imgErr != nil {
 			return imgui.MarkdownImageData{}
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/AllenDang/imgui-go v1.12.1-0.20220118055608-8cbd98e97ca2
 	github.com/faiface/mainthread v0.0.0-20171120011319-8b78f0a41ae3
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec
-	github.com/go-resty/resty/v2 v2.7.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/sahilm/fuzzy v0.1.0
 	github.com/stretchr/testify v1.7.0
@@ -19,7 +18,6 @@ require (
 	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.0.0-20211029224645-99673261e6eb // indirect
 	golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6 h1:zDw5v7qm4yH7N8C8uWd+8I
 github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec h1:3FLiRYO6PlQFDpUU7OEFlWgjGD1jnBIVSJ5SYRWk+9c=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
-github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
@@ -26,13 +24,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d h1:RNPAfi2nHY7C2srAV8A49jpsYr0ADedCk1wq6fTMTvs=
 golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb h1:pirldcYWx7rx7kE5r+9WsOXPXK0+WH5+uZ7uPmJ44uM=
-golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 h1:X/2sJAybVknnUnV7AD2HdT6rm2p5BP6eH2j+igduWgk=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
This reduces the dependency complexity, given that the usage is very simple. Reduces the example application size for image and markdown by ~1MB each.