### PR TITLE
Font scaling (mostly for Linux)

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -252,9 +252,7 @@ func rebuildFontAtlas() {
 			}
 
 			// Scale font size with DPI scale factor
-			if runtime.GOOS == windows {
-				fontInfo.size *= Context.GetPlatform().GetContentScale()
-			}
+			fontInfo.size *= Context.GetPlatform().GetContentScale()
 
 			if len(fontInfo.fontByte) == 0 {
 				fonts.AddFontFromFileTTFV(fontInfo.fontPath, fontInfo.size, fontConfig, ranges.Data())
@@ -274,9 +272,7 @@ func rebuildFontAtlas() {
 	// Add extra fonts
 	for _, fontInfo := range extraFonts {
 		// Scale font size with DPI scale factor
-		if runtime.GOOS == windows {
-			fontInfo.size *= Context.GetPlatform().GetContentScale()
-		}
+		fontInfo.size *= Context.GetPlatform().GetContentScale()
 
 		// Store imgui.Font for PushFont
 		var f imgui.Font

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -252,12 +252,12 @@ func rebuildFontAtlas() {
 			}
 
 			// Scale font size with DPI scale factor
-			fontInfo.size *= Context.GetPlatform().GetContentScale()
+			scaledSize := fontInfo.size * Context.GetPlatform().GetContentScale()
 
 			if len(fontInfo.fontByte) == 0 {
-				fonts.AddFontFromFileTTFV(fontInfo.fontPath, fontInfo.size, fontConfig, ranges.Data())
+				fonts.AddFontFromFileTTFV(fontInfo.fontPath, scaledSize, fontConfig, ranges.Data())
 			} else {
-				fonts.AddFontFromMemoryTTFV(fontInfo.fontByte, fontInfo.size, fontConfig, ranges.Data())
+				fonts.AddFontFromMemoryTTFV(fontInfo.fontByte, scaledSize, fontConfig, ranges.Data())
 			}
 		}
 
@@ -272,14 +272,14 @@ func rebuildFontAtlas() {
 	// Add extra fonts
 	for _, fontInfo := range extraFonts {
 		// Scale font size with DPI scale factor
-		fontInfo.size *= Context.GetPlatform().GetContentScale()
+		scaledSize := fontInfo.size * Context.GetPlatform().GetContentScale()
 
 		// Store imgui.Font for PushFont
 		var f imgui.Font
 		if len(fontInfo.fontByte) == 0 {
-			f = fonts.AddFontFromFileTTFV(fontInfo.fontPath, fontInfo.size, imgui.DefaultFontConfig, ranges.Data())
+			f = fonts.AddFontFromFileTTFV(fontInfo.fontPath, scaledSize, imgui.DefaultFontConfig, ranges.Data())
 		} else {
-			f = fonts.AddFontFromMemoryTTFV(fontInfo.fontByte, fontInfo.size, imgui.DefaultFontConfig, ranges.Data())
+			f = fonts.AddFontFromMemoryTTFV(fontInfo.fontByte, scaledSize, imgui.DefaultFontConfig, ranges.Data())
 		}
 		extraFontMap[fontInfo.String()] = &f
 	}


### PR DESCRIPTION
**DO NOT MERGE BLINDLY**

As stated in #437, currently no font scaling happens on Linux, but it seems to be needed. This PR wants to look into this issue a lil' bit...

Changes in this PR:
- enable font scaling on Linux (and technically also Mac, but `GetContentScale` always returns 1 there)
- Fixed: when scaling was used, extraFonts would not load, because the scaled size was written as a key. 

Open points so far:
- if I see this correctly, DPI settings are not updated. I.e. when moving the window to another monitor with other DPI settings, those do not apply. Shall this be fixed, or is this intended?
- there is also a call to `style.ScaleAllSizes` in MasterWindow.go#setTheme, that is only executed on Windows. Enabling this also in Linux -- shows no difference. What should I expect here?

@macbutch, @HACKERALERT: As you were also dealing with DPI scaling issues (#350), do you have any input here? What platforms were you on?