### PR TITLE
package: add appripiate ld flag for static linking on for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go environment
         uses: actions/setup-go@v2.1.5
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
         id: go
 
       - name: Cache Go modules

--- a/build_windows.go
+++ b/build_windows.go
@@ -1,5 +1,6 @@
 //go:build windows
-//+build windows
+// +build windows
+
 package giu
 
 // #cgo LDFLAGS: -static

--- a/build_windows.go
+++ b/build_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+package giu
+
+// #cgo LDFLAGS: -static
+import "C"

--- a/build_windows.go
+++ b/build_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+//+build windows
 package giu
 
 // #cgo LDFLAGS: -static


### PR DESCRIPTION
fix #452 
@AllenDang idk how to add another ldflags like `-s -w -H=windowsgui` as only `-static` works and another one causes build crash :-(