### PR TITLE
Small bugfix for ImageWidget OnClick detection

### DIFF
--- a/ImageWidgets.go
+++ b/ImageWidgets.go
@@ -88,7 +88,7 @@ func (i *ImageWidget) Build() {
 	}
 
 	// trick: detect click event
-	if i.onClick != nil && IsMouseClicked(MouseButtonLeft) {
+	if i.onClick != nil && IsMouseClicked(MouseButtonLeft) && IsWindowFocused(0) {
 		cursorPos := GetCursorScreenPos()
 		mousePos := GetMousePos()
 		mousePos.Add(cursorPos)


### PR DESCRIPTION
Added check if the current window is focused to OnClick detection of ImageWidget.

Without this ImageWidgets will also detect OnClick if there is a click on a overlapping window on top. Feel free to reject the PR, if this is desired.

There currenlty is a workaround like:
```go
giu.Custom(func() {
    img := giu.Image(texture)
    if giu.IsWindowFocused(0) {
	img = img.OnClick(onClick)
    }
    img.Build()
})
```