### PR TITLE
Textures: remove panic call when executing NewTexture before calling …

### DIFF
--- a/Texture.go
+++ b/Texture.go
@@ -35,7 +35,6 @@ func EnqueueNewTextureFromRgba(rgba image.Image, loadCb func(t *Texture)) {
 
 // NewTextureFromRgba creates a new texture from image.Image and, when it is done, calls loadCallback(loadedTexture).
 func NewTextureFromRgba(rgba image.Image, loadCallback func(*Texture)) {
-	Assert(Context.isRunning, "", "NewTextureFromRgba", "cannot load texture befor (*MasterWindow).Run call!")
 	loadTexture(rgba, loadCallback)
 }
 


### PR DESCRIPTION
…(*MasterWindow).Run

no idea why is it necessary. everything seems working.
I had to forget about removeing something in #451

fix #494 and fix #498