### PR TITLE
add Chinese fonts on linux

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -99,6 +99,17 @@ func newFontAtlas() FontAtlas {
 				size:     result.fontSize + 1,
 			},
 		})
+		// Chinese fonts
+		result.registerDefaultFonts([]FontInfo{
+			{
+				fontName: "wqy-microhei",
+				size:     result.fontSize + 1,
+			},
+			{
+				fontName: "SourceHanSansCN",
+				size:     result.fontSize + 3,
+			},
+		})
 	}
 
 	return result


### PR DESCRIPTION
Add Chinese fonts on linux.
In China, wqy-* fonts is very popular among Linux users.
SourceHanSansCN maybe default Chinese font on Manjaro Linux.