### PR TITLE
Added generic functions for context management

### DIFF
--- a/ClickableWidgets.go
+++ b/ClickableWidgets.go
@@ -329,17 +329,14 @@ func (b *ImageButtonWithRgbaWidget) FramePadding(padding int) *ImageButtonWithRg
 
 // Build implements Widget interface.
 func (b *ImageButtonWithRgbaWidget) Build() {
-	if state := Context.GetState(b.id); state == nil {
-		Context.SetState(b.id, &imageState{})
+	if state := GetState[imageState](Context, b.id); state == nil {
+		SetState(&Context, b.id, &imageState{})
 
 		NewTextureFromRgba(b.rgba, func(tex *Texture) {
-			Context.SetState(b.id, &imageState{texture: tex})
+			SetState(&Context, b.id, &imageState{texture: tex})
 		})
 	} else {
-		var isOk bool
-		imgState, isOk := state.(*imageState)
-		Assert(isOk, "ImageButtonWithRgbaWidget", "Build", "got unexpected type of widget's state")
-		b.ImageButtonWidget.texture = imgState.texture
+		b.ImageButtonWidget.texture = state.texture
 	}
 
 	b.ImageButtonWidget.Build()

--- a/CodeEditor.go
+++ b/CodeEditor.go
@@ -204,17 +204,12 @@ func (ce *CodeEditorWidget) Build() {
 }
 
 func (ce *CodeEditorWidget) getState() (state *codeEditorState) {
-	if s := Context.GetState(ce.title); s == nil {
+	if state = GetState[codeEditorState](Context, ce.title); state == nil {
 		state = &codeEditorState{
 			editor: imgui.NewTextEditor(),
 		}
 
-		Context.SetState(ce.title, state)
-	} else {
-		var isOk bool
-		state, isOk = s.(*codeEditorState)
-		Assert(isOk, "CodeEditorWidget", "getState", "unexpected widget's state type")
+		SetState(&Context, ce.title, state)
 	}
-
 	return state
 }

--- a/Context.go
+++ b/Context.go
@@ -1,6 +1,7 @@
 package giu
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/AllenDang/imgui-go"
@@ -14,6 +15,11 @@ var Context context
 // Dispose method is called when state is removed from context.
 type Disposable interface {
 	Dispose()
+}
+
+type genericDisposable[T any] interface {
+	Disposable
+	*T
 }
 
 type state struct {
@@ -101,19 +107,40 @@ func (c *context) cleanState() {
 	c.widgetIndexCounter = 0
 }
 
+func SetState[T any, PT genericDisposable[T]](c *context, id string, data PT) {
+	c.state.Store(id, &state{valid: true, data: data})
+}
+
 func (c *context) SetState(id string, data Disposable) {
 	c.state.Store(id, &state{valid: true, data: data})
 }
 
+func GetState[T any, PT genericDisposable[T]](c context, id string) PT {
+	if s, ok := c.load(id); ok {
+		s.valid = true
+		data, isOk := s.data.(PT)
+		Assert(isOk, "Context", "GetState", fmt.Sprintf("got state of unexpected type: expected %T, instead found %T", new(T), s.data))
+		return data
+
+	}
+	return nil
+}
+
 func (c *context) GetState(id string) any {
+	if s, ok := c.load(id); ok {
+		s.valid = true
+		return s.data
+	}
+	return nil
+}
+
+func (c *context) load(id any) (*state, bool) {
 	if v, ok := c.state.Load(id); ok {
 		if s, ok := v.(*state); ok {
-			s.valid = true
-			return s.data
+			return s, true
 		}
 	}
-
-	return nil
+	return nil, false
 }
 
 // Get widget index for current layout.

--- a/EventHandler.go
+++ b/EventHandler.go
@@ -122,14 +122,9 @@ func (eh *EventHandler) Build() {
 	if eh.onActivate != nil || eh.onDeactivate != nil {
 		var state *eventHandlerState
 		stateID := GenAutoID("eventHandlerState")
-		if s := Context.GetState(stateID); s != nil {
-			var isOk bool
-			state, isOk = s.(*eventHandlerState)
-			Assert(isOk, "EventHandler", "Build", "unexpected type of state received")
-		} else {
-			newState := &eventHandlerState{}
-			Context.SetState(stateID, newState)
-			state = newState
+		if state = GetState[eventHandlerState](Context, stateID); state == nil {
+			state = &eventHandlerState{}
+			SetState(&Context, stateID, state)
 		}
 
 		if eh.onActivate != nil && isActive && !state.isActive {

--- a/ExtraWidgets.go
+++ b/ExtraWidgets.go
@@ -435,13 +435,9 @@ func (l *ListBoxWidget) OnMenu(onMenu func(selectedIndex int, menu string)) *Lis
 // nolint:gocognit // will fix later
 func (l *ListBoxWidget) Build() {
 	var state *ListBoxState
-	if s := Context.GetState(l.id); s == nil {
+	if state = GetState[ListBoxState](Context, l.id); state == nil {
 		state = &ListBoxState{selectedIndex: 0}
-		Context.SetState(l.id, state)
-	} else {
-		var isOk bool
-		state, isOk = s.(*ListBoxState)
-		Assert(isOk, "ListBoxWidget", "Build", "wrong state type recovered")
+		SetState(&Context, l.id, state)
 	}
 
 	child := Child().Border(l.border).Size(l.width, l.height).Layout(Layout{

--- a/ImageWidgets.go
+++ b/ImageWidgets.go
@@ -217,9 +217,10 @@ func (i *ImageWithFileWidget) OnClick(cb func()) *ImageWithFileWidget {
 
 // Build implements Widget interface.
 func (i *ImageWithFileWidget) Build() {
-	imgState := &imageState{}
-	if imgState := GetState[imageState](Context, i.id); imgState == nil {
+	var imgState *imageState
+	if imgState = GetState[imageState](Context, i.id); imgState == nil {
 		// Prevent multiple invocation to LoadImage.
+		imgState = &imageState{}
 		SetState(&Context, i.id, imgState)
 
 		img, err := LoadImage(i.imgPath)
@@ -305,9 +306,9 @@ func (i *ImageWithURLWidget) LayoutForFailure(widgets ...Widget) *ImageWithURLWi
 
 // Build implements Widget interface.
 func (i *ImageWithURLWidget) Build() {
-	imgState := &imageState{}
-
-	if imgState := GetState[imageState](Context, i.id); imgState == nil {
+	var imgState *imageState
+	if imgState = GetState[imageState](Context, i.id); imgState == nil {
+		imgState = &imageState{}
 		SetState(&Context, i.id, imgState)
 
 		// Prevent multiple invocation to download image.

--- a/ImageWidgets.go
+++ b/ImageWidgets.go
@@ -160,17 +160,13 @@ func (i *ImageWithRgbaWidget) OnClick(cb func()) *ImageWithRgbaWidget {
 func (i *ImageWithRgbaWidget) Build() {
 	if i.rgba != nil {
 		var imgState *imageState
-		if state := Context.GetState(i.id); state == nil {
+		if imgState = GetState[imageState](Context, i.id); imgState == nil {
 			imgState = &imageState{}
-			Context.SetState(i.id, imgState)
+			SetState(&Context, i.id, imgState)
 
 			NewTextureFromRgba(i.rgba, func(tex *Texture) {
 				imgState.texture = tex
 			})
-		} else {
-			var isOk bool
-			imgState, isOk = state.(*imageState)
-			Assert(isOk, "ImageWithRgbaWidget", "Build", "unexpected type of widget's state recovered")
 		}
 
 		i.img.texture = imgState.texture
@@ -222,9 +218,9 @@ func (i *ImageWithFileWidget) OnClick(cb func()) *ImageWithFileWidget {
 // Build implements Widget interface.
 func (i *ImageWithFileWidget) Build() {
 	imgState := &imageState{}
-	if state := Context.GetState(i.id); state == nil {
+	if imgState := GetState[imageState](Context, i.id); imgState == nil {
 		// Prevent multiple invocation to LoadImage.
-		Context.SetState(i.id, imgState)
+		SetState(&Context, i.id, imgState)
 
 		img, err := LoadImage(i.imgPath)
 		if err == nil {
@@ -232,10 +228,6 @@ func (i *ImageWithFileWidget) Build() {
 				imgState.texture = tex
 			})
 		}
-	} else {
-		var isOk bool
-		imgState, isOk = state.(*imageState)
-		Assert(isOk, "ImageWithFileWidget", "Build", "wrong type of widget's state got")
 	}
 
 	i.img.texture = imgState.texture
@@ -315,15 +307,15 @@ func (i *ImageWithURLWidget) LayoutForFailure(widgets ...Widget) *ImageWithURLWi
 func (i *ImageWithURLWidget) Build() {
 	imgState := &imageState{}
 
-	if state := Context.GetState(i.id); state == nil {
-		Context.SetState(i.id, imgState)
+	if imgState := GetState[imageState](Context, i.id); imgState == nil {
+		SetState(&Context, i.id, imgState)
 
 		// Prevent multiple invocation to download image.
 		downloadContext, cancalFunc := ctx.WithCancel(ctx.Background())
-		Context.SetState(i.id, &imageState{loading: true, cancel: cancalFunc})
+		SetState(&Context, i.id, &imageState{loading: true, cancel: cancalFunc})
 
 		errorFn := func(err error) {
-			Context.SetState(i.id, &imageState{failure: true})
+			SetState(&Context, i.id, &imageState{failure: true})
 
 			// Trigger onFailure event
 			if i.onFailure != nil {
@@ -361,7 +353,7 @@ func (i *ImageWithURLWidget) Build() {
 			rgba := ImageToRgba(img)
 
 			NewTextureFromRgba(rgba, func(tex *Texture) {
-				Context.SetState(i.id, &imageState{
+				SetState(&Context, i.id, &imageState{
 					loading: false,
 					failure: false,
 					texture: tex,
@@ -373,10 +365,6 @@ func (i *ImageWithURLWidget) Build() {
 				i.onReady()
 			}
 		}()
-	} else {
-		var isOk bool
-		imgState, isOk = state.(*imageState)
-		Assert(isOk, "ImageWithURLWidget", "Build", "wrong type of widget's state recovered.")
 	}
 
 	switch {

--- a/MemoryEditor.go
+++ b/MemoryEditor.go
@@ -44,16 +44,12 @@ func (me *MemoryEditorWidget) Build() {
 }
 
 func (me *MemoryEditorWidget) getState() (state *memoryEditorState) {
-	if s := Context.GetState(me.id); s == nil {
+	if state = GetState[memoryEditorState](Context, me.id); state == nil {
 		state = &memoryEditorState{
 			editor: imgui.NewMemoryEditor(),
 		}
 
-		Context.SetState(me.id, state)
-	} else {
-		var ok bool
-		state, ok = s.(*memoryEditorState)
-		Assert(ok, "MemoryEditorWidget", "getState", "incorrect state type recovered.")
+		SetState(&Context, me.id, state)
 	}
 
 	return state

--- a/Msgbox.go
+++ b/Msgbox.go
@@ -103,7 +103,7 @@ func PrepareMsgbox() Layout {
 			var state *msgboxState
 
 			// Register state.
-			if state := GetState[msgboxState](Context, msgboxID); state == nil {
+			if state = GetState[msgboxState](Context, msgboxID); state == nil {
 				state = &msgboxState{title: "Info", content: "Content", buttons: MsgboxButtonsOk, resultCallback: nil, open: false}
 				SetState(&Context, msgboxID, state)
 			}

--- a/Msgbox.go
+++ b/Msgbox.go
@@ -103,15 +103,9 @@ func PrepareMsgbox() Layout {
 			var state *msgboxState
 
 			// Register state.
-			stateRaw := Context.GetState(msgboxID)
-
-			if stateRaw == nil {
+			if state := GetState[msgboxState](Context, msgboxID); state == nil {
 				state = &msgboxState{title: "Info", content: "Content", buttons: MsgboxButtonsOk, resultCallback: nil, open: false}
-				Context.SetState(msgboxID, state)
-			} else {
-				var isOk bool
-				state, isOk = stateRaw.(*msgboxState)
-				Assert(isOk, "MsgboxWidget", "PrepareMsgbox", "got state of unexpected type")
+				SetState(&Context, msgboxID, state)
 			}
 
 			if state.open {
@@ -122,7 +116,7 @@ func PrepareMsgbox() Layout {
 			PopupModal(fmt.Sprintf("%s%s", state.title, msgboxID)).Layout(
 				Custom(func() {
 					// Ensure the state is valid.
-					Context.GetState(msgboxID)
+					GetState[msgboxState](Context, msgboxID)
 				}),
 				Label(state.content).Wrapped(true),
 				buildMsgboxButtons(state.buttons, state.resultCallback),
@@ -135,15 +129,12 @@ func PrepareMsgbox() Layout {
 type MsgboxWidget struct{}
 
 func (m *MsgboxWidget) getState() *msgboxState {
-	stateRaw := Context.GetState(msgboxID)
-	if stateRaw == nil {
+	state := GetState[msgboxState](Context, msgboxID)
+	if state == nil {
 		panic("Msgbox is not prepared. Invoke giu.PrepareMsgbox in the end of the layout.")
 	}
 
-	result, isOk := stateRaw.(*msgboxState)
-	Assert(isOk, "MsgboxWidget", "getState", "unexpected type of widget's state recovered")
-
-	return result
+	return state
 }
 
 // Msgbox opens message box.

--- a/ProgressIndicator.go
+++ b/ProgressIndicator.go
@@ -62,16 +62,12 @@ func ProgressIndicator(label string, width, height, radius float32) *ProgressInd
 // Build implements Widget interface.
 func (p *ProgressIndicatorWidget) Build() {
 	// State exists
-	if s := Context.GetState(p.internalID); s == nil {
+	if state := GetState[progressIndicatorState](Context, p.internalID); state == nil {
 		// Register state and start go routine
 		ps := progressIndicatorState{angle: 0.0, stop: false}
-		Context.SetState(p.internalID, &ps)
+		SetState(&Context, p.internalID, &ps)
 		go ps.update()
 	} else {
-		var isOk bool
-		state, isOk := s.(*progressIndicatorState)
-		Assert(isOk, "ProgressIndicatorWidget", "Build", "got unexpected type of widget's sate")
-
 		child := Child().Border(false).Size(p.width, p.height).Layout(Layout{
 			Custom(func() {
 				// Process width and height

--- a/SplitLayout.go
+++ b/SplitLayout.go
@@ -159,14 +159,9 @@ func (s *SplitLayoutWidget) buildChild(width, height float32, layout Widget) Wid
 }
 
 func (s *SplitLayoutWidget) getState() (state *splitLayoutState) {
-	if st := Context.GetState(s.id); st == nil {
+	if state = GetState[splitLayoutState](Context, s.id); state == nil {
 		state = &splitLayoutState{delta: 0.0}
-		Context.SetState(s.id, state)
-	} else {
-		var isOk bool
-		state, isOk = st.(*splitLayoutState)
-		Assert(isOk, "SplitLayoutWidget", "Build", "got unexpected type of widget's state")
+		SetState(&Context, s.id, state)
 	}
-
 	return state
 }

--- a/TextWidgets.go
+++ b/TextWidgets.go
@@ -228,13 +228,9 @@ func (i *InputTextWidget) OnChange(onChange func()) *InputTextWidget {
 func (i *InputTextWidget) Build() {
 	// Get state
 	var state *inputTextState
-	if s := Context.GetState(i.label); s == nil {
+	if state = GetState[inputTextState](Context, i.label); state == nil {
 		state = &inputTextState{}
-		Context.SetState(i.label, state)
-	} else {
-		var isOk bool
-		state, isOk = s.(*inputTextState)
-		Assert(isOk, "InputTextWidget", "Build", "wrong state type recovered.")
+		SetState(&Context, i.label, state)
 	}
 
 	if i.width != 0 {

--- a/Window.go
+++ b/Window.go
@@ -188,15 +188,9 @@ func (w *WindowWidget) getStateID() string {
 
 // returns window state.
 func (w *WindowWidget) getState() (state *windowState) {
-	if s := Context.GetState(w.getStateID()); s != nil {
-		var isOk bool
-		state, isOk = s.(*windowState)
-		Assert(isOk, "WindowWidget", "getState", "unexpected state recovered.")
-	} else {
+	if state = GetState[windowState](Context, w.getStateID()); state == nil {
 		state = &windowState{}
-
-		Context.SetState(w.getStateID(), state)
+		SetState(&Context, w.getStateID(), state)
 	}
-
 	return state
 }


### PR DESCRIPTION
Hi @AllenDang @gucio321 I saw #517 and since I've been using generics a lot recently, I figured I'd try my hand at making the changes.

The `GetState` and `SetState` functions still exist on the `context` struct for backwards compatibility, but there are now generic versions of them.
I've also updated the "internal" code to use the generic version instead.
I've kept the assert still for `GetState` to catch/prevent any mixing up of types.

The "reason" behind `[T any, genericDisposable[T]]` is explained [here](https://go.googlesource.com/proposal/+/HEAD/design/43651-type-parameters.md#pointer-method-example)
Although I'm using it to directly call `Dispose`, it helps enforce the Disposable interface and it's also needed to have the return type as a pointer of the generic type.

Feel free to make any changes that you see fit.