### PR TITLE
{ci} Clean up golangci job

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,37 +8,24 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
-    name: lint
-    runs-on: ubuntu-latest
+    name: Lint
+    runs-on: macos-latest
     steps:
-      - uses: actions/setup-go@v3
+      - name: Check out source code
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
-      - name: Set up LibGL, Mesa & X11 libraries
-        run: |
-          sudo apt-get --allow-releaseinfo-change update
-          sudo apt-get install -y libgtk-3-dev libasound2-dev libxxf86vm-dev
-      - uses: actions/checkout@v3
-      - name: golangci-lint
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.50.1
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-
-          # skip-build-cache: true


### PR DESCRIPTION
- use macOS for runner to avoid extra updating/downloading
- use the go.mod file to determine go version