### PR TITLE
govet: Use pointers for Context and FontAtlas

### DIFF
--- a/ClickableWidgets.go
+++ b/ClickableWidgets.go
@@ -330,10 +330,10 @@ func (b *ImageButtonWithRgbaWidget) FramePadding(padding int) *ImageButtonWithRg
 // Build implements Widget interface.
 func (b *ImageButtonWithRgbaWidget) Build() {
 	if state := GetState[imageState](Context, b.id); state == nil {
-		SetState(&Context, b.id, &imageState{})
+		SetState(Context, b.id, &imageState{})
 
 		NewTextureFromRgba(b.rgba, func(tex *Texture) {
-			SetState(&Context, b.id, &imageState{texture: tex})
+			SetState(Context, b.id, &imageState{texture: tex})
 		})
 	} else {
 		b.ImageButtonWidget.texture = state.texture

--- a/CodeEditor.go
+++ b/CodeEditor.go
@@ -209,7 +209,7 @@ func (ce *CodeEditorWidget) getState() (state *codeEditorState) {
 			editor: imgui.NewTextEditor(),
 		}
 
-		SetState(&Context, ce.title, state)
+		SetState(Context, ce.title, state)
 	}
 
 	return state

--- a/Context.go
+++ b/Context.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Context represents a giu context.
-var Context context
+var Context *context
 
 // Disposable should be implemented by all states stored in context.
 // Dispose method is called when state is removed from context.
@@ -44,14 +44,14 @@ type context struct {
 	state sync.Map
 
 	InputHandler InputHandler
-	FontAtlas    FontAtlas
+	FontAtlas    *FontAtlas
 
 	textureLoadingQueue *queue.Queue
 
 	cssStylesheet cssStylesheet
 }
 
-func CreateContext(p imgui.Platform, r imgui.Renderer) context {
+func CreateContext(p imgui.Platform, r imgui.Renderer) *context {
 	result := context{
 		platform:      p,
 		renderer:      r,
@@ -70,7 +70,7 @@ func CreateContext(p imgui.Platform, r imgui.Renderer) context {
 		result.FontAtlas.shouldRebuildFontAtlas = true
 	}
 
-	return result
+	return &result
 }
 
 func (c *context) GetRenderer() imgui.Renderer {
@@ -117,7 +117,7 @@ func (c *context) SetState(id string, data Disposable) {
 	c.state.Store(id, &state{valid: true, data: data})
 }
 
-func GetState[T any, PT genericDisposable[T]](c context, id string) PT {
+func GetState[T any, PT genericDisposable[T]](c *context, id string) PT {
 	if s, ok := c.load(id); ok {
 		s.valid = true
 		data, isOk := s.data.(PT)

--- a/Context_test.go
+++ b/Context_test.go
@@ -31,7 +31,7 @@ func Test_SetGetState(t *testing.T) {
 		t.Run(tc.id, func(t *testing.T) {
 			ctx := context{}
 			SetState(&ctx, tc.id, tc.data)
-			restored := GetState[teststate](ctx, tc.id)
+			restored := GetState[teststate](&ctx, tc.id)
 			assert.Equal(t, tc.data, restored, "unexpected state restored")
 		})
 	}
@@ -50,7 +50,7 @@ func Test_SetGetStateGeneric(t *testing.T) {
 		t.Run(tc.id, func(t *testing.T) {
 			ctx := context{}
 			SetState(&ctx, tc.id, tc.data)
-			restored := GetState[teststate](ctx, tc.id)
+			restored := GetState[teststate](&ctx, tc.id)
 			assert.Equal(t, tc.data, restored, "unexpected state restored")
 		})
 	}
@@ -67,7 +67,7 @@ func Test_SetGetWrongStateGeneric(t *testing.T) {
 		}
 	}()
 	SetState(&ctx, id, data)
-	GetState[teststate2](ctx, id)
+	GetState[teststate2](&ctx, id)
 }
 
 func Test_invalidState(t *testing.T) {
@@ -86,13 +86,13 @@ func Test_invalidState(t *testing.T) {
 
 	ctx.invalidAllState()
 
-	_ = GetState[teststate](ctx, state2ID)
+	_ = GetState[teststate](&ctx, state2ID)
 
 	ctx.cleanState()
 
-	assert.NotNil(t, GetState[teststate](ctx, state2ID),
+	assert.NotNil(t, GetState[teststate](&ctx, state2ID),
 		"although state has been accessed during the frame, it has ben deleted by invalidAllState/cleanState")
-	assert.Nil(t, GetState[teststate](ctx, state1ID),
+	assert.Nil(t, GetState[teststate](&ctx, state1ID),
 		"although state hasn't been accessed during the frame, it hasn't ben deleted by invalidAllState/cleanState")
 }
 

--- a/EventHandler.go
+++ b/EventHandler.go
@@ -126,7 +126,7 @@ func (eh *EventHandler) Build() {
 		stateID := GenAutoID("eventHandlerState")
 		if state = GetState[eventHandlerState](Context, stateID); state == nil {
 			state = &eventHandlerState{}
-			SetState(&Context, stateID, state)
+			SetState(Context, stateID, state)
 		}
 
 		if eh.onActivate != nil && isActive && !state.isActive {

--- a/ExtraWidgets.go
+++ b/ExtraWidgets.go
@@ -464,7 +464,7 @@ func (l *ListBoxWidget) Build() {
 	var state *ListBoxState
 	if state = GetState[ListBoxState](Context, l.id); state == nil {
 		state = &ListBoxState{selectedIndex: 0}
-		SetState(&Context, l.id, state)
+		SetState(Context, l.id, state)
 	}
 
 	child := Child().Border(l.border).Size(l.width, l.height).Layout(Layout{

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -54,7 +54,7 @@ type FontAtlas struct {
 	fontSize               float32
 }
 
-func newFontAtlas() FontAtlas {
+func newFontAtlas() *FontAtlas {
 	result := FontAtlas{
 		extraFontMap: make(map[string]*imgui.Font),
 		fontSize:     defaultFontSize,
@@ -112,7 +112,7 @@ func newFontAtlas() FontAtlas {
 		})
 	}
 
-	return result
+	return &result
 }
 
 // SetDefaultFontSize sets the default font size. Invoke this before MasterWindow.NewMasterWindow(..).

--- a/ImageWidgets.go
+++ b/ImageWidgets.go
@@ -166,7 +166,7 @@ func (i *ImageWithRgbaWidget) Build() {
 		var imgState *imageState
 		if imgState = GetState[imageState](Context, i.id); imgState == nil {
 			imgState = &imageState{}
-			SetState(&Context, i.id, imgState)
+			SetState(Context, i.id, imgState)
 
 			NewTextureFromRgba(i.rgba, func(tex *Texture) {
 				imgState.texture = tex
@@ -225,7 +225,7 @@ func (i *ImageWithFileWidget) Build() {
 	if imgState = GetState[imageState](Context, i.id); imgState == nil {
 		// Prevent multiple invocation to LoadImage.
 		imgState = &imageState{}
-		SetState(&Context, i.id, imgState)
+		SetState(Context, i.id, imgState)
 
 		img, err := LoadImage(i.imgPath)
 		if err == nil {
@@ -313,15 +313,15 @@ func (i *ImageWithURLWidget) Build() {
 	var imgState *imageState
 	if imgState = GetState[imageState](Context, i.id); imgState == nil {
 		imgState = &imageState{}
-		SetState(&Context, i.id, imgState)
+		SetState(Context, i.id, imgState)
 
 		// Prevent multiple invocation to download image.
 		downloadContext, cancelFunc := ctx.WithCancel(ctx.Background())
 
-		SetState(&Context, i.id, &imageState{loading: true, cancel: cancelFunc})
+		SetState(Context, i.id, &imageState{loading: true, cancel: cancelFunc})
 
 		errorFn := func(err error) {
-			SetState(&Context, i.id, &imageState{failure: true})
+			SetState(Context, i.id, &imageState{failure: true})
 
 			// Trigger onFailure event
 			if i.onFailure != nil {
@@ -360,7 +360,7 @@ func (i *ImageWithURLWidget) Build() {
 			rgba := ImageToRgba(img)
 
 			NewTextureFromRgba(rgba, func(tex *Texture) {
-				SetState(&Context, i.id, &imageState{
+				SetState(Context, i.id, &imageState{
 					loading: false,
 					failure: false,
 					texture: tex,

--- a/MemoryEditor.go
+++ b/MemoryEditor.go
@@ -49,7 +49,7 @@ func (me *MemoryEditorWidget) getState() (state *memoryEditorState) {
 			editor: imgui.NewMemoryEditor(),
 		}
 
-		SetState(&Context, me.id, state)
+		SetState(Context, me.id, state)
 	}
 
 	return state

--- a/Msgbox.go
+++ b/Msgbox.go
@@ -106,7 +106,7 @@ func PrepareMsgbox() Layout {
 			// Register state.
 			if state = GetState[msgboxState](Context, msgboxID); state == nil {
 				state = &msgboxState{title: "Info", content: "Content", buttons: MsgboxButtonsOk, resultCallback: nil, open: false}
-				SetState(&Context, msgboxID, state)
+				SetState(Context, msgboxID, state)
 			}
 
 			if state.open {

--- a/ProgressIndicator.go
+++ b/ProgressIndicator.go
@@ -68,7 +68,7 @@ func (p *ProgressIndicatorWidget) Build() {
 		// Register state and start go routine
 		ps := progressIndicatorState{angle: 0.0, stop: false}
 
-		SetState(&Context, p.internalID, &ps)
+		SetState(Context, p.internalID, &ps)
 
 		go ps.update()
 	} else {

--- a/SplitLayout.go
+++ b/SplitLayout.go
@@ -162,7 +162,7 @@ func (s *SplitLayoutWidget) buildChild(width, height float32, layout Widget) Wid
 func (s *SplitLayoutWidget) getState() (state *splitLayoutState) {
 	if state = GetState[splitLayoutState](Context, s.id); state == nil {
 		state = &splitLayoutState{delta: 0.0}
-		SetState(&Context, s.id, state)
+		SetState(Context, s.id, state)
 	}
 
 	return state

--- a/TextWidgets.go
+++ b/TextWidgets.go
@@ -230,7 +230,7 @@ func (i *InputTextWidget) Build() {
 	var state *inputTextState
 	if state = GetState[inputTextState](Context, i.label); state == nil {
 		state = &inputTextState{}
-		SetState(&Context, i.label, state)
+		SetState(Context, i.label, state)
 	}
 
 	if i.width != 0 {

--- a/Window.go
+++ b/Window.go
@@ -193,7 +193,7 @@ func (w *WindowWidget) getStateID() string {
 func (w *WindowWidget) getState() (state *windowState) {
 	if state = GetState[windowState](Context, w.getStateID()); state == nil {
 		state = &windowState{}
-		SetState(&Context, w.getStateID(), state)
+		SetState(Context, w.getStateID(), state)
 	}
 
 	return state


### PR DESCRIPTION
govet was complaining about copying these because they contain mutex locks which should never be copied.

"copylocks: call of GetState[teststate] copies lock value"

Fixes #588