### PR TITLE
Linting: Turn off conflicting linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,34 +1,4 @@
 ---
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-  gocyclo:
-    min-complexity: 15
-  goimports:
-    local-prefixes: github.com/AllenDang/giu
-  govet:
-    check-shadowing: true
-  # lll:
-  #   line-length: 140
-  maligned:
-    suggest-new: true
-  misspell:
-    locale: US
-
 linters:
   disable-all: true
   enable:
@@ -42,7 +12,7 @@ linters:
     - exportloopref
     - forcetypeassert
     #- funlen
-    - gci
+    #- gci
     - godot
     #- gochecknoglobals
     #- gochecknoinits
@@ -52,7 +22,7 @@ linters:
     - gocyclo
     - goerr113
     - gofmt
-    - gofumpt
+    #- gofumpt
     - goheader
     - goimports
     #- gomnd
@@ -82,6 +52,31 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
+
+linters-settings:
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+  gocyclo:
+    min-complexity: 15
+  goimports:
+    local-prefixes: github.com/AllenDang/giu
+  govet:
+    check-shadowing: true
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
 
 run:
   timeout: 5m


### PR DESCRIPTION
- `gofumpt` conflicts with `wsl`
- `gci` conflicts with `goimports`

`gofumpt` and `gci` don't add that much that isn't already covered by `wsl` and  `goimports` anyways.

Also reorder file to be more logical & clean up unused settings.