### PR TITLE
readme: add paragraph about documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ E-mail: allengnr@gmail.com
 
 Individuals: support continued development and maintenance [here](https://patreon.com/AllenDang).
 
+## Documentation
+
+For documentation refer to [our wiki](https://github.com/AllenDang/giu/wiki),
+[examples](./examples), [GoDoc](https://pkg.go.dev/github.com/AllenDang/giu),
+or just review comments in code.
+
+
 ## Supported Platforms
 
 giu is built upon GLFW v3.3, so ideally giu could support all platforms that GLFW v3.3 supports.


### PR DESCRIPTION
@AllenDang let me know what do you think about my (maybe too radical) changes in documentation (epecially wiki/discussion/readme).

In case of this PR:
I think our readme should clearly point where we hold our documentation so that we can point it at any time in issues.