### PR TITLE
examples: fix crash in codeeditor demo

### DIFF
--- a/examples/codeeditor/codeeditor.go
+++ b/examples/codeeditor/codeeditor.go
@@ -47,6 +47,8 @@ func loop() {
 }
 
 func main() {
+	wnd := g.NewMasterWindow("Code Editor", 800, 600, 0)
+
 	errMarkers = imgui.NewErrorMarkers()
 
 	editor = g.CodeEditor().
@@ -56,6 +58,5 @@ func main() {
 		LanguageDefinition(giu.LanguageDefinitionSQL).
 		Border(true)
 
-	wnd := g.NewMasterWindow("Code Editor", 800, 600, 0)
 	wnd.Run(loop)
 }


### PR DESCRIPTION
it is important to call NewMasterWindow before doing anything in giu (since we don't use init funcs anymore)

fix #689 