### PR TITLE
mainthread: disable on windows

### DIFF
--- a/mainthread_all.go
+++ b/mainthread_all.go
@@ -1,5 +1,5 @@
-//go:build !darwin
-// +build !darwin
+//go:build !darwin && !windows
+// +build !darwin,!windows
 
 package giu
 

--- a/mainthread_windows.go
+++ b/mainthread_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+// +build windows
+
+package giu
+
+// TODO: I have no working mainthread library for windows.
+// - this one for macOS crashes app immediately
+// - this for linux (and everything else) freezes after a few seconds
+// 
+// With no mianthread support this at least runs sometimes. Just keep your giu calls in one thread and everything should work.
+func mainthreadCallPlatform(c func()) {
+	c()
+}


### PR DESCRIPTION
in reference to https://github.com/AllenDang/giu/issues/735#issuecomment-1951419027 we have no mainthread library that works on windows. Due to this fact I think that the best solution is to disable mainthread completely for winows until we find some working solution.

I'll create an issue about this as soon as this change is merged to master