### PR TITLE
fix: Unknown key: 161 on AZERTY keyboard

### DIFF
--- a/Keycode.go
+++ b/Keycode.go
@@ -120,6 +120,8 @@ const (
 	KeyRightAlt       = Key(imgui.KeyRightAlt)
 	KeyRightSuper     = Key(imgui.KeyRightSuper)
 	KeyMenu           = Key(imgui.KeyMenu)
+	KeyWorld1         = Key(imgui.GLFWKeyWorld1)
+	KeyWorld2         = Key(imgui.GLFWKeyWorld2)
 )
 
 // refer glfw3.h.
@@ -230,6 +232,8 @@ func keyFromGLFWKey(k imgui.GLFWKey) Key {
 		imgui.GLFWKeyRightAlt:     KeyRightAlt,
 		imgui.GLFWKeyRightSuper:   KeyRightSuper,
 		imgui.GLFWKeyMenu:         KeyMenu,
+		imgui.GLFWKeyWorld1:       KeyWorld1,
+		imgui.GLFWKeyWorld2:       KeyWorld2,
 	}
 
 	if v, ok := data[k]; ok {


### PR DESCRIPTION
Hello, I'm using AZERTY keyboard and got a panic when I'm using the key "<>" (161) 

```
2024/03/25 21:13:33 Unknown key: 161
panic: Unknown key: 161

goroutine 51 [running]:
log.Panicf({0xd2ebf2?, 0xc000079bf0?}, {0xc000079be0?, 0x40eb0b?, 0x47623a?})
        /usr/local/go/src/log/log.go:439 +0x65
github.com/AllenDang/giu.keyFromGLFWKey(0xa1)
        /home/raph/go/pkg/mod/github.com/!allen!dang/giu@v0.7.1-0.20240322134328-961651810cda/Keycode.go:239 +0x105
github.com/AllenDang/giu.(*MasterWindow).SetInputHandler.func1(0x0?, 0xa1?, 0x1, 0x0)
        /home/raph/go/pkg/mod/github.com/!allen!dang/giu@v0.7.1-0.20240322134328-961651810cda/MasterWindow.go:390 +0x38
github.com/AllenDang/cimgui-go.(*GLFWBackend).SetKeyCallback.func1(0xa1, 0x5e, 0x1, 0x0)
        /home/raph/go/pkg/mod/github.com/!allen!dang/cimgui-go@v0.0.0-20240324100345-e81e703b7b87/glfw_backend.go:435 +0x64
github.com/AllenDang/cimgui-go.keyCallback(0xc000079d00?, 0xa1, 0x5e, 0x1, 0x0)
        /home/raph/go/pkg/mod/github.com/!allen!dang/cimgui-go@v0.0.0-20240324100345-e81e703b7b87/backend.go:76 +0x67
github.com/AllenDang/cimgui-go._Cfunc_igGLFWRunLoop(0x2b6c190, 0x691450, 0x6914c0, 0x691530, 0x691610)
        _cgo_gotypes.go:24265 +0x45
github.com/AllenDang/cimgui-go.(*GLFWBackend).Run.func1(0x1?)
        /home/raph/go/pkg/mod/github.com/!allen!dang/cimgui-go@v0.0.0-20240324100345-e81e703b7b87/glfw_backend.go:249 +0x9c
github.com/AllenDang/cimgui-go.(*GLFWBackend).Run(0x0?, 0x0?)
        /home/raph/go/pkg/mod/github.com/!allen!dang/cimgui-go@v0.0.0-20240324100345-e81e703b7b87/glfw_backend.go:249 +0x32
main.main.(*MasterWindow).Run.func2()
        /home/raph/go/pkg/mod/github.com/!allen!dang/giu@v0.7.1-0.20240322134328-961651810cda/MasterWindow.go:244 +0xcb
github.com/faiface/mainthread.Run.func1()
        /home/raph/go/pkg/mod/github.com/faiface/mainthread@v0.0.0-20171120011319-8b78f0a41ae3/mainthread.go:37 +0x22
created by github.com/faiface/mainthread.Run in goroutine 1
        /home/raph/go/pkg/mod/github.com/faiface/mainthread@v0.0.0-20171120011319-8b78f0a41ae3/mainthread.go:36 +0xae
exit status 2

```

I fixed it by adding GLFWKeyWorld1 from here https://github.com/AllenDang/cimgui-go/blob/e81e703b7b872f28c671c03abf69ae6854caa7f7/glfw_backend.h#L61

According to glfw keyboard key tokens here https://www.glfw.org/docs/latest/group__keys.html

I also added GLFWKeyWorld2 because it wasn't there, even if I never had a problem with it.