### PR TITLE
Fix panic and font alats

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -242,7 +242,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 	}
 
 	fonts := Context.IO().Fonts()
-	// fonts.Clear() /// TODO: I'm commenting this out, because it produces panic.
+	fonts.Clear()
 
 	var sb strings.Builder
 

--- a/Keycode.go
+++ b/Keycode.go
@@ -122,6 +122,7 @@ const (
 	KeyMenu           = Key(imgui.KeyMenu)
 	KeyWorld1         = Key(imgui.GLFWKeyWorld1)
 	KeyWorld2         = Key(imgui.GLFWKeyWorld2)
+	KeyUnknown        = Key(-1)
 )
 
 // refer glfw3.h.
@@ -234,6 +235,7 @@ func keyFromGLFWKey(k imgui.GLFWKey) Key {
 		imgui.GLFWKeyMenu:         KeyMenu,
 		imgui.GLFWKeyWorld1:       KeyWorld1,
 		imgui.GLFWKeyWorld2:       KeyWorld2,
+		-1:                        KeyUnknown,
 	}
 
 	if v, ok := data[k]; ok {


### PR DESCRIPTION
@gucio321 Can you help to test whether giu will still crash on linux? I add the fonts.Clear() back in order to display Chinese characters.