### PR TITLE
Fixed issue with resizing events in GLFW master window

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -188,7 +188,7 @@ func (w *MasterWindow) setTheme() (fin func()) {
 }
 
 func (w *MasterWindow) sizeChange(width, height int) {
-	// noop
+	w.beforeRender()
 }
 
 func (w *MasterWindow) beforeRender() {
@@ -206,7 +206,6 @@ func (w *MasterWindow) beforeRender() {
 }
 
 func (w *MasterWindow) afterRender() {
-	Context.cleanState()
 }
 
 func (w *MasterWindow) beforeDestroy() {
@@ -215,6 +214,8 @@ func (w *MasterWindow) beforeDestroy() {
 }
 
 func (w *MasterWindow) render() {
+	Context.cleanState()
+
 	fin := w.setTheme()
 	defer fin()
 


### PR DESCRIPTION
The effect is particularly visible in the drawing of tables during window resizing

beforeRender() now called from sizeChange() in MasterWindow.go. this is because beforeRender() is never called when resizing a GLFW window

context.CleanSlate() moved from afterRender() to beginning of render() function. this is because afterRender(), like beforeRender() is never called when resizing

it would be ineffective to call CleanSlate() from the sizeChange() function. calling CleanSlate() at the beginning of the render() has the same affect as calling it from afterRender() in all situations.