### PR TITLE
fix bug of center and right alignment

### DIFF
--- a/Alignment.go
+++ b/Alignment.go
@@ -139,19 +139,15 @@ func (a *AlignmentSetter) Build() {
 		currentPos := GetCursorPos()
 		w := GetWidgetWidth(item)
 		availableW, _ := GetAvailableRegion()
-		// we need to increase available region by 2 * window padding (X),
-		// because GetCursorPos considers it
-		paddingW, _ := GetWindowPadding()
-		availableW += 2 * paddingW
 
 		// set cursor position to align the widget
 		switch a.alignType {
 		case AlignLeft:
 			SetCursorPos(currentPos)
 		case AlignCenter:
-			SetCursorPos(image.Pt(int(availableW/2-w/2), currentPos.Y))
+			SetCursorPos(image.Pt(int(availableW/2-w/2)+currentPos.X, currentPos.Y))
 		case AlignRight:
-			SetCursorPos(image.Pt(int(availableW-w), currentPos.Y))
+			SetCursorPos(image.Pt(int(availableW-w)+currentPos.X, currentPos.Y))
 		default:
 			panic(fmt.Sprintf("giu: (*AlignSetter).Build: unknown align type %d", a.alignType))
 		}


### PR DESCRIPTION
The current right-aligned element will extend slightly beyond the main interface. And when the element is in a container, there is a deviation from the starting position between center and right alignment. Just add the offset at the starting position in the original code and remove the calculation of the border.

before:
![image](https://github.com/user-attachments/assets/4aa01696-abb7-4b0a-a7f4-b2bbcf7f1d9f)

after:
![5696b7a674633dbda8ad503af6165b4](https://github.com/user-attachments/assets/4fa60cc2-75ae-4205-a311-eee62a7d465d)
