### PR TITLE
examples/dragdrop: fix crash

### DIFF
--- a/examples/dragdrop/dragdrop.go
+++ b/examples/dragdrop/dragdrop.go
@@ -16,11 +16,11 @@ func loop() {
 			g.Custom(func() {
 				g.Button("Drag me: 9").Build()
 				if imgui.BeginDragDropSource() {
-					data := 9
+					data := int(9)
 					imgui.SetDragDropPayload(
 						"DND_DEMO",
 						uintptr(unsafe.Pointer(&data)),
-						0,
+						uint64(unsafe.Sizeof(data)),
 					)
 					g.Label("9").Build()
 					imgui.EndDragDropSource()
@@ -33,7 +33,7 @@ func loop() {
 					imgui.SetDragDropPayload(
 						"DND_DEMO",
 						uintptr(unsafe.Pointer(&data)),
-						0,
+						uint64(unsafe.Sizeof(data)),
 					)
 					g.Label("10").Build()
 					imgui.EndDragDropSource()
@@ -44,8 +44,8 @@ func loop() {
 		g.Custom(func() {
 			if imgui.BeginDragDropTarget() {
 				payload := imgui.AcceptDragDropPayload("DND_DEMO")
-				if payload != nil {
-					dropTarget = fmt.Sprintf("Dropped value: %d", payload.Data())
+				if payload != nil && payload.CData != nil {
+					dropTarget = fmt.Sprintf("Dropped value: %d", *(*int)(unsafe.Pointer(payload.Data())))
 				}
 				imgui.EndDragDropTarget()
 			}


### PR DESCRIPTION
There were 3 problems:
- call to SetDragDropPayload declared data_size always as 0
- null chceck in DragDropTarget checked only if returned payload isn't nil but didn't if CData isn't (cimgui-go changs - generally should be fixed in cimgui-go somehow)
- there was also a small issue in result decoding as the label presented pointer address and not its value

resolve #832