### PR TITLE
Add MasterWindowFlagsHidden

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -25,6 +25,8 @@ const (
 	MasterWindowFlagsFrameless
 	// Specifies whether the window will be transparent.
 	MasterWindowFlagsTransparent
+	// Specifies wheter the windows will be hidden (for use with multiple windows)
+	MasterWindowFlagsHidden
 )
 
 // parseAndApply converts MasterWindowFlags to appropriate imgui.GLFWWindowFlags.
@@ -38,6 +40,7 @@ func (m MasterWindowFlags) parseAndApply(b imgui.Backend[imgui.GLFWWindowFlags])
 		MasterWindowFlagsFloating:     {imgui.GLFWWindowFlagsFloating, 1},
 		MasterWindowFlagsFrameless:    {imgui.GLFWWindowFlagsDecorated, 0},
 		MasterWindowFlagsTransparent:  {imgui.GLFWWindowFlagsTransparent, 1},
+		MasterWindowFlagsHidden:       {imgui.GLFWWindowFlagsVisible, 0},
 	}
 
 	for flag, d := range data {

--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -25,7 +25,7 @@ const (
 	MasterWindowFlagsFrameless
 	// Specifies whether the window will be transparent.
 	MasterWindowFlagsTransparent
-	// Specifies wheter the windows will be hidden (for use with multiple windows)
+	// Specifies wheter the windows will be hidden (for use with multiple windows).
 	MasterWindowFlagsHidden
 )
 

--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -25,7 +25,7 @@ const (
 	MasterWindowFlagsFrameless
 	// Specifies whether the window will be transparent.
 	MasterWindowFlagsTransparent
-	// Specifies wheter the windows will be hidden (for use with multiple windows).
+	// Specifies whether the window will be hidden (for use with multiple windows).
 	MasterWindowFlagsHidden
 )
 


### PR DESCRIPTION
Update MasterWindow witj GLFWWindowsFlagsVisible access

It is used by cases where we really don't want any native window decoration.
It usually implies this MasterWindow preambule

```
	imgui.CreateContext()
	io := imgui.CurrentIO()
	io.SetConfigViewportsNoAutoMerge(true)
	io.SetConfigViewportsNoDefaultParent(true)
	wnd := g.NewMasterWindow("Client", 1, 1,g.MasterWindowFlagsHidden|g.MasterWindowFlagsFrameless)
	wnd.Run(loop)
```