### PR TITLE
HOTFIX: fix giu state system

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -214,6 +214,7 @@ func (w *MasterWindow) beforeRender() {
 }
 
 func (w *MasterWindow) afterRender() {
+	Context.cleanState()
 }
 
 func (w *MasterWindow) beforeDestroy() {
@@ -222,8 +223,6 @@ func (w *MasterWindow) beforeDestroy() {
 }
 
 func (w *MasterWindow) render() {
-	Context.cleanState()
-
 	fin := w.setTheme()
 	defer fin()
 


### PR DESCRIPTION
Context.cleanState was called at the first line of render() function and Context.invalidAllState was called in BeforeRenderHook

Both were called before rendering - it caused every state was regenerated every frame

fix #862