### PR TITLE
Revert "Fixed issue with resizing events in GLFW master window"

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -196,7 +196,7 @@ func (w *MasterWindow) setTheme() (fin func()) {
 }
 
 func (w *MasterWindow) sizeChange(width, height int) {
-	w.beforeRender()
+	// noop
 }
 
 func (w *MasterWindow) beforeRender() {
@@ -214,6 +214,7 @@ func (w *MasterWindow) beforeRender() {
 }
 
 func (w *MasterWindow) afterRender() {
+	Context.cleanState()
 }
 
 func (w *MasterWindow) beforeDestroy() {
@@ -222,8 +223,6 @@ func (w *MasterWindow) beforeDestroy() {
 }
 
 func (w *MasterWindow) render() {
-	Context.cleanState()
-
 	fin := w.setTheme()
 	defer fin()
 


### PR DESCRIPTION
Reverts AllenDang/giu#831

Reasons:
- causes #862 (giant problems with performence and overall giu functionalities)
- I see absolutly no reason why beforeRender should be called in OnSizeChange (After fixing state mechanism, calling beforeRender in OnSizeChange doesn't help) - I'll open an issue for the problem with hube list example..

close #863, close #862