### PR TITLE
mw: move steate clean/invalidation calls to the main render function

### DIFF
--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -200,7 +200,6 @@ func (w *MasterWindow) sizeChange(_, _ int) {
 }
 
 func (w *MasterWindow) beforeRender() {
-	Context.invalidAllState()
 	Context.FontAtlas.rebuildFontAtlas()
 
 	// process texture load requests
@@ -214,7 +213,6 @@ func (w *MasterWindow) beforeRender() {
 }
 
 func (w *MasterWindow) afterRender() {
-	Context.cleanState()
 }
 
 func (w *MasterWindow) beforeDestroy() {
@@ -223,6 +221,8 @@ func (w *MasterWindow) beforeDestroy() {
 }
 
 func (w *MasterWindow) render() {
+	Context.invalidAllState()
+
 	fin := w.setTheme()
 	defer fin()
 
@@ -234,6 +234,8 @@ func (w *MasterWindow) render() {
 	mainStylesheet.Push()
 	w.updateFunc()
 	mainStylesheet.Pop()
+
+	Context.cleanState()
 }
 
 // Run runs the main loop.


### PR DESCRIPTION
reasons:
- due to a bug in cimgui-go (https://github.com/AllenDang/cimgui-go/issues/345) before/after render callbacks are not called correctly