### PR TITLE
mainthread: lock main os threa on Windows

### DIFF
--- a/mainthread_windows.go
+++ b/mainthread_windows.go
@@ -3,11 +3,21 @@
 
 package giu
 
-// TODO: I have no working mainthread library for windows.
+import "runtime"
+
+// according to:
+// https://github.com/AllenDang/giu/issues/881
+// this init solves some windows problems.
+// However I'm not sure about implications of this. Will turn out later.
+func init() {
+	runtime.LockOSThread()
+}
+
+// I have no working mainthread library for windows.
 // - this one for macOS crashes app immediately
 // - this for linux (and everything else) freezes after a few seconds
-// 
-// With no mianthread support this at least runs sometimes. Just keep your giu calls in one thread and everything should work.
+//
+// this seems to solve an issue: https://github.com/AllenDang/giu/issues/881
 func mainthreadCallPlatform(c func()) {
 	c()
 }


### PR DESCRIPTION
fixes #881 close 764 with a note that this commit may have some unexpected consequences in which case it could be reverted.