### PR TITLE
Upgrade cimgui go to v1.1.0

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/AllenDang/cimgui-go/imgui"
+	"github.com/AllenDang/cimgui-go/utils"
 	"github.com/AllenDang/go-findfont"
 )
 
@@ -300,7 +301,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 			} else {
 				fontConfig.SetFontDataOwnedByAtlas(false)
 				fonts.AddFontFromMemoryTTFV(
-					uintptr(unsafe.Pointer(imgui.SliceToPtr(fontInfo.fontByte))),
+					uintptr(unsafe.Pointer(utils.SliceToPtr(fontInfo.fontByte))),
 					int32(len(fontInfo.fontByte)),
 					fontInfo.size,
 					fontConfig,
@@ -338,7 +339,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 			fontConfig := imgui.NewFontConfig()
 			fontConfig.SetFontDataOwnedByAtlas(false)
 			f = fonts.AddFontFromMemoryTTFV(
-				uintptr(unsafe.Pointer(imgui.SliceToPtr(fontInfo.fontByte))),
+				uintptr(unsafe.Pointer(utils.SliceToPtr(fontInfo.fontByte))),
 				int32(len(fontInfo.fontByte)),
 				fontInfo.size,
 				fontConfig,

--- a/Plot.go
+++ b/Plot.go
@@ -4,6 +4,7 @@ import (
 	"image"
 
 	"github.com/AllenDang/cimgui-go/implot"
+	"github.com/AllenDang/cimgui-go/utils"
 )
 
 type (
@@ -238,7 +239,7 @@ func (p *PlotCanvasWidget) Build() {
 		if len(p.xTicksValue) > 0 {
 			implot.PlotSetupAxisTicksdoublePtrV(
 				implot.AxisX1,
-				&p.xTicksValue,
+				utils.SliceToPtr(p.xTicksValue),
 				int32(len(p.xTicksValue)),
 				p.xTicksLabel,
 				p.xTicksShowDefault,
@@ -248,7 +249,7 @@ func (p *PlotCanvasWidget) Build() {
 		if len(p.yTicksValue) > 0 {
 			implot.PlotSetupAxisTicksdoublePtrV(
 				implot.AxisY1,
-				&p.yTicksValue,
+				utils.SliceToPtr(p.yTicksValue),
 				int32(len(p.yTicksValue)),
 				p.yTicksLabel,
 				p.yTicksShowDefault,
@@ -340,7 +341,7 @@ func (p *BarPlot) Offset(offset int) *BarPlot {
 func (p *BarPlot) Plot() {
 	implot.PlotPlotBarsdoublePtrIntV(
 		p.title,
-		&p.data,
+		utils.SliceToPtr(p.data),
 		int32(len(p.data)),
 		p.width,
 		p.shift,
@@ -392,7 +393,7 @@ func (p *BarHPlot) Offset(offset int) *BarHPlot {
 func (p *BarHPlot) Plot() {
 	implot.PlotPlotBarsdoublePtrIntV(
 		Context.FontAtlas.RegisterString(p.title),
-		&p.data,
+		utils.SliceToPtr(p.data),
 		int32(len(p.data)),
 		p.height,
 		p.shift,
@@ -454,7 +455,7 @@ func (p *LinePlot) Plot() {
 
 	implot.PlotPlotLinedoublePtrIntV(
 		Context.FontAtlas.RegisterString(p.title),
-		&p.values,
+		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
 		p.xScale,
 		p.x0,
@@ -499,8 +500,8 @@ func (p *LineXYPlot) Plot() {
 	implot.PlotSetAxis(implot.PlotAxisEnum(p.yAxis))
 	implot.PlotPlotLinedoublePtrdoublePtrV(
 		Context.FontAtlas.RegisterString(p.title),
-		&p.xs,
-		&p.ys,
+		utils.SliceToPtr(p.xs),
+		utils.SliceToPtr(p.ys),
 		int32(len(p.xs)),
 		0, // flags
 		int32(p.offset),
@@ -560,7 +561,7 @@ func (p *PieChartPlot) Plot() {
 
 	implot.PlotPlotPieChartdoublePtrStrV(
 		Context.FontAtlas.RegisterStringSlice(p.labels),
-		&p.values,
+		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
 		p.x,
 		p.y,
@@ -612,7 +613,7 @@ func (p *ScatterPlot) Offset(offset int) *ScatterPlot {
 func (p *ScatterPlot) Plot() {
 	implot.PlotPlotScatterdoublePtrIntV(
 		Context.FontAtlas.RegisterString(p.label),
-		&p.values,
+		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
 		p.xscale,
 		p.x0,
@@ -649,8 +650,8 @@ func (p *ScatterXYPlot) Offset(offset int) *ScatterXYPlot {
 func (p *ScatterXYPlot) Plot() {
 	implot.PlotPlotScatterdoublePtrdoublePtrV(
 		Context.FontAtlas.RegisterString(p.label),
-		&p.xs,
-		&p.ys,
+		utils.SliceToPtr(p.xs),
+		utils.SliceToPtr(p.ys),
 		int32(len(p.xs)),
 		0, // TODO: implement
 		int32(p.offset),

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.1
 
 require (
-	github.com/AllenDang/cimgui-go v1.0.4-0.20241026200445-990a0e771992
+	github.com/AllenDang/cimgui-go v1.1.0
 	github.com/AllenDang/go-findfont v0.0.0-20200702051237-9f180485aeb8
 	github.com/faiface/mainthread v0.0.0-20171120011319-8b78f0a41ae3
 	github.com/mazznoer/csscolorparser v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/AllenDang/cimgui-go v1.0.4-0.20241026200445-990a0e771992 h1:gLSKrpQ89PEJQ9t2EzTcblz7qsAQvLoCjDLdt5s7RFI=
-github.com/AllenDang/cimgui-go v1.0.4-0.20241026200445-990a0e771992/go.mod h1:aY20nGDN5w+zaGAmRV24bKI/OYVmEptB0qlr5z/0OoI=
+github.com/AllenDang/cimgui-go v1.1.0 h1:hltblxjy6Q+/TxOQLjI45yVlCn/DQSC9DLTtKc8PhfQ=
+github.com/AllenDang/cimgui-go v1.1.0/go.mod h1:v5iftKz+rJRG6TArxibxqqOhVqUyzMkqbX90iC2Mqe0=
 github.com/AllenDang/go-findfont v0.0.0-20200702051237-9f180485aeb8 h1:dKZMqib/yUDoCFigmz2agG8geZ/e3iRq304/KJXqKyw=
 github.com/AllenDang/go-findfont v0.0.0-20200702051237-9f180485aeb8/go.mod h1:b4uuDd0s6KRIPa84cEEchdQ9ICh7K0OryZHbSzMca9k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This Pull Request updates cimgui-go to v1.1.0 manually (as some annoying guy - I don't know him at all - did breaking changes since last release).

I attach release notes - just in case:

<details><summary>cimgui-go v1.1.0 Release Notes</summary>


# Introduction
Hi!
We present another release of cimgui-go today.
Its major highlights are:
- implementation of the ImGuizmo extension
- Imgui update
- bugfix in glfwbackend causing GL error in some circumstances.
- fix of crucial issues in the internal conversions mechanism
- package layout redesign (**BREAKING CHANGE**)
- change of type for all in/out slices to pointers (**BREAKING CHANGE**)
- improvement of `Vector` type - it now shares the Slice() method.

## Breaking Changes
- if you use a slice as an argument to cimgui-go function, replace it with `utils.SliceToPtr(yourslice)`
   - this was necessary, because we cannot in fact determine whether a C pointer is a Slice or Pointer. Conversion from slice to pointer is easier and makes more sense than conversion from ptr to slice.
   - There was an issue making it impossible to pass an empty slice or nil (runtime panic)
- ConvertCTypes and some Wrap* functions have been hidden.
   -  you shouldn't have to use these functions - its use should be handled internally by cimgui-go. They are highly unsafe.
- `imgui.Vector` was moved to `vectors.Vector`
   - Vector type does not belong to the `imgui` package so putting it there isn't the right approach.
- `imgui.SliceToPtr` was moved to `utils.SliceToPtr`
   - As above: this function does not belong to `imgui`'s code and should not be there.
- `datautils` package was renamed to `utils`.
   - `Does it make it work better?` - No, but this name is shorter. This package was entirely redesigned anyway so a name change will not break much more.

We are so sorry for these breaking changes. We hope their positive impact on your project will be much greater than your dissatisfaction related to implementing them. We promise we'll try to avoid them in future releases so that you can update smoothly.

## What's Changed
* Update imgui to 646df390032f64eb03f8b5e2e5cbaf0c8e3bb237 by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/355
* hotfix(glfwbackend): revert part of #348 by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/356
* add ImGuizmo plugin by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/297
* hotfix(datautils): WrapNumberPtr now works as expected by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/357
* codegen: get rid of simplePtrSliceW  by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/358
* examples: add gizmo usage example by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/359
* build(deps): bump github.com/hajimehoshi/ebiten/v2 from 2.8.1 to 2.8.2 by @dependabot in https://github.com/AllenDang/cimgui-go/pull/360
* Reorder pkg by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/361
* Add imguizmo comments by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/362
* Vectors rework by @gucio321 in https://github.com/AllenDang/cimgui-go/pull/363


**Full Changelog**: https://github.com/AllenDang/cimgui-go/compare/v1.0.3...v1.1.0

</details>