### PR TITLE
Upgrade cimgui go (introduce func names changes)

### DIFF
--- a/Flags.go
+++ b/Flags.go
@@ -471,47 +471,47 @@ const (
 	SliderFlagsInvalidMask = SliderFlags(imgui.SliderFlagsInvalidMask)
 )
 
-// PlotFlags represents implot.PlotFlags.
-type PlotFlags implot.PlotFlags
+// PlotFlags represents implot.Flags.
+type PlotFlags implot.Flags
 
 // plot flags.
 const (
-	PlotFlagsNone        = PlotFlags(implot.PlotFlagsNone)
-	PlotFlagsNoTitle     = PlotFlags(implot.PlotFlagsNoTitle)
-	PlotFlagsNoLegend    = PlotFlags(implot.PlotFlagsNoLegend)
-	PlotFlagsNoMenus     = PlotFlags(implot.PlotFlagsNoMenus)
-	PlotFlagsNoBoxSelect = PlotFlags(implot.PlotFlagsNoBoxSelect)
-	// 	PlotFlagsNoMousePos  = PlotFlags(implot.PlotFlagsNoMousePos)
-	// 	PlotFlagsNoHighlight = PlotFlags(implot.PlotFlagsNoHighlight)
-	// PlotFlagsNoChild = PlotFlags(implot.PlotFlagsNoChild).
-	PlotFlagsEqual = PlotFlags(implot.PlotFlagsEqual)
-	// 	PlotFlagsYAxis2      = PlotFlags(implot.PlotFlagsYAxis2)
-	// 	PlotFlagsYAxis3      = PlotFlags(implot.PlotFlagsYAxis3)
-	// 	PlotFlagsQuery       = PlotFlags(implot.PlotFlagsQuery)
-	PlotFlagsCrosshairs = PlotFlags(implot.PlotFlagsCrosshairs)
-	// 	PlotFlagsAntiAliased = PlotFlags(implot.PlotFlagsAntiAliased)
-	PlotFlagsCanvasOnly = PlotFlags(implot.PlotFlagsCanvasOnly)
+	PlotFlagsNone        = PlotFlags(implot.FlagsNone)
+	PlotFlagsNoTitle     = PlotFlags(implot.FlagsNoTitle)
+	PlotFlagsNoLegend    = PlotFlags(implot.FlagsNoLegend)
+	PlotFlagsNoMenus     = PlotFlags(implot.FlagsNoMenus)
+	PlotFlagsNoBoxSelect = PlotFlags(implot.FlagsNoBoxSelect)
+	// 	PlotFlagsNoMousePos  = PlotFlags(implot.FlagsNoMousePos)
+	// 	PlotFlagsNoHighlight = PlotFlags(implot.FlagsNoHighlight)
+	// PlotFlagsNoChild = PlotFlags(implot.FlagsNoChild).
+	PlotFlagsEqual = PlotFlags(implot.FlagsEqual)
+	// 	PlotFlagsYAxis2      = PlotFlags(implot.FlagsYAxis2)
+	// 	PlotFlagsYAxis3      = PlotFlags(implot.FlagsYAxis3)
+	// 	PlotFlagsQuery       = PlotFlags(implot.FlagsQuery)
+	PlotFlagsCrosshairs = PlotFlags(implot.FlagsCrosshairs)
+	// 	PlotFlagsAntiAliased = PlotFlags(implot.FlagsAntiAliased)
+	PlotFlagsCanvasOnly = PlotFlags(implot.FlagsCanvasOnly)
 )
 
-// PlotAxisFlags represents implot.PlotAxisFlags.
-type PlotAxisFlags implot.PlotAxisFlags
+// PlotAxisFlags represents implot.AxisFlags.
+type PlotAxisFlags implot.AxisFlags
 
 // plot axis flags.
 const (
-	PlotAxisFlagsNone         PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsNone)
-	PlotAxisFlagsNoLabel      PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsNoLabel)
-	PlotAxisFlagsNoGridLines  PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsNoGridLines)
-	PlotAxisFlagsNoTickMarks  PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsNoTickMarks)
-	PlotAxisFlagsNoTickLabels PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsNoTickLabels)
-	PlotAxisFlagsForeground   PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsForeground)
-	//	PlotAxisFlagsLogScale      PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsLogScale)
-	//	PlotAxisFlagsTime          PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsTime)
-	PlotAxisFlagsInvert        PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsInvert)
-	PlotAxisFlagsNoInitialFit  PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsNoInitialFit)
-	PlotAxisFlagsAutoFit       PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsAutoFit)
-	PlotAxisFlagsRangeFit      PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsRangeFit)
-	PlotAxisFlagsLockMin       PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsLockMin)
-	PlotAxisFlagsLockMax       PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsLockMax)
-	PlotAxisFlagsLock          PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsLock)
-	PlotAxisFlagsNoDecorations PlotAxisFlags = PlotAxisFlags(implot.PlotAxisFlagsNoDecorations)
+	PlotAxisFlagsNone         PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsNone)
+	PlotAxisFlagsNoLabel      PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsNoLabel)
+	PlotAxisFlagsNoGridLines  PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsNoGridLines)
+	PlotAxisFlagsNoTickMarks  PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsNoTickMarks)
+	PlotAxisFlagsNoTickLabels PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsNoTickLabels)
+	PlotAxisFlagsForeground   PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsForeground)
+	//	PlotAxisFlagsLogScale      PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsLogScale)
+	//	PlotAxisFlagsTime          PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsTime)
+	PlotAxisFlagsInvert        PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsInvert)
+	PlotAxisFlagsNoInitialFit  PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsNoInitialFit)
+	PlotAxisFlagsAutoFit       PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsAutoFit)
+	PlotAxisFlagsRangeFit      PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsRangeFit)
+	PlotAxisFlagsLockMin       PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsLockMin)
+	PlotAxisFlagsLockMax       PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsLockMax)
+	PlotAxisFlagsLock          PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsLock)
+	PlotAxisFlagsNoDecorations PlotAxisFlags = PlotAxisFlags(implot.AxisFlagsNoDecorations)
 )

--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -83,8 +83,8 @@ type MasterWindow struct {
 func NewMasterWindow(title string, width, height int, flags MasterWindowFlags) *MasterWindow {
 	imGuiContext := imgui.CreateContext()
 
-	implot.PlotCreateContext()
-	imnodes.ImNodesCreateContext()
+	implot.CreateContext()
+	imnodes.CreateContext()
 
 	io := imgui.CurrentIO()
 
@@ -226,8 +226,8 @@ func (w *MasterWindow) afterRender() {
 }
 
 func (w *MasterWindow) beforeDestroy() {
-	implot.PlotDestroyContext()
-	imnodes.ImNodesDestroyContext()
+	implot.DestroyContext()
+	imnodes.DestroyContext()
 }
 
 func (w *MasterWindow) render() {

--- a/Plot.go
+++ b/Plot.go
@@ -9,9 +9,9 @@ import (
 
 type (
 	// PlotXAxis allows to chose X axis.
-	PlotXAxis = implot.PlotAxisEnum
+	PlotXAxis = implot.AxisEnum
 	// PlotYAxis allows to chose Y axis.
-	PlotYAxis = implot.PlotAxisEnum
+	PlotYAxis = implot.AxisEnum
 )
 
 // Available axes.
@@ -218,26 +218,26 @@ func (p *PlotCanvasWidget) Build() {
 		return
 	}
 
-	if implot.PlotBeginPlotV(
+	if implot.BeginPlotV(
 		Context.FontAtlas.RegisterString(p.title),
 		ToVec2(image.Pt(p.width, p.height)),
-		implot.PlotFlags(p.flags),
+		implot.Flags(p.flags),
 	) {
-		implot.PlotSetupAxisLimitsV(
+		implot.SetupAxisLimitsV(
 			implot.AxisX1,
 			p.xMin,
 			p.xMax,
-			implot.PlotCond(p.axisLimitCondition),
+			implot.Cond(p.axisLimitCondition),
 		)
-		implot.PlotSetupAxisLimitsV(
+		implot.SetupAxisLimitsV(
 			implot.AxisY1,
 			p.yMin,
 			p.yMax,
-			implot.PlotCond(p.axisLimitCondition),
+			implot.Cond(p.axisLimitCondition),
 		)
 
 		if len(p.xTicksValue) > 0 {
-			implot.PlotSetupAxisTicksdoublePtrV(
+			implot.SetupAxisTicksdoublePtrV(
 				implot.AxisX1,
 				utils.SliceToPtr(p.xTicksValue),
 				int32(len(p.xTicksValue)),
@@ -247,7 +247,7 @@ func (p *PlotCanvasWidget) Build() {
 		}
 
 		if len(p.yTicksValue) > 0 {
-			implot.PlotSetupAxisTicksdoublePtrV(
+			implot.SetupAxisTicksdoublePtrV(
 				implot.AxisY1,
 				utils.SliceToPtr(p.yTicksValue),
 				int32(len(p.yTicksValue)),
@@ -256,31 +256,31 @@ func (p *PlotCanvasWidget) Build() {
 			)
 		}
 
-		implot.PlotSetupAxisV(
+		implot.SetupAxisV(
 			implot.AxisX1,
 			Context.FontAtlas.RegisterString(p.xLabel),
-			implot.PlotAxisFlags(p.xFlags),
+			implot.AxisFlags(p.xFlags),
 		)
 
-		implot.PlotSetupAxisV(
+		implot.SetupAxisV(
 			implot.AxisY1,
 			Context.FontAtlas.RegisterString(p.yLabel),
-			implot.PlotAxisFlags(p.yFlags),
+			implot.AxisFlags(p.yFlags),
 		)
 
 		if p.y2Label != "" {
-			implot.PlotSetupAxisV(
+			implot.SetupAxisV(
 				implot.AxisY2,
 				Context.FontAtlas.RegisterString(p.y2Label),
-				implot.PlotAxisFlags(p.y2Flags),
+				implot.AxisFlags(p.y2Flags),
 			)
 		}
 
 		if p.y3Label != "" {
-			implot.PlotSetupAxisV(
+			implot.SetupAxisV(
 				implot.AxisY3,
 				Context.FontAtlas.RegisterString(p.y3Label),
-				implot.PlotAxisFlags(p.y3Flags),
+				implot.AxisFlags(p.y3Flags),
 			)
 		}
 
@@ -288,14 +288,14 @@ func (p *PlotCanvasWidget) Build() {
 			plot.Plot()
 		}
 
-		implot.PlotEndPlot()
+		implot.EndPlot()
 	}
 }
 
 // SwitchPlotAxes switches plot axes.
 func SwitchPlotAxes(x PlotXAxis, y PlotYAxis) PlotWidget {
 	return Custom(func() {
-		implot.PlotSetAxes(x, y)
+		implot.SetAxes(x, y)
 	})
 }
 
@@ -339,7 +339,7 @@ func (p *BarPlot) Offset(offset int) *BarPlot {
 
 // Plot implements Plot interface.
 func (p *BarPlot) Plot() {
-	implot.PlotPlotBarsdoublePtrIntV(
+	implot.PlotBarsdoublePtrIntV(
 		p.title,
 		utils.SliceToPtr(p.data),
 		int32(len(p.data)),
@@ -391,13 +391,13 @@ func (p *BarHPlot) Offset(offset int) *BarHPlot {
 
 // Plot implements plot interface.
 func (p *BarHPlot) Plot() {
-	implot.PlotPlotBarsdoublePtrIntV(
+	implot.PlotBarsdoublePtrIntV(
 		Context.FontAtlas.RegisterString(p.title),
 		utils.SliceToPtr(p.data),
 		int32(len(p.data)),
 		p.height,
 		p.shift,
-		implot.PlotBarsFlagsHorizontal,
+		implot.BarsFlagsHorizontal,
 		int32(p.offset),
 		0,
 	)
@@ -449,11 +449,11 @@ func (p *LinePlot) Offset(offset int) *LinePlot {
 
 // Plot implements Plot interface.
 func (p *LinePlot) Plot() {
-	implot.PlotSetAxis(
-		implot.PlotAxisEnum(p.yAxis),
+	implot.SetAxis(
+		implot.AxisEnum(p.yAxis),
 	)
 
-	implot.PlotPlotLinedoublePtrIntV(
+	implot.PlotLinedoublePtrIntV(
 		Context.FontAtlas.RegisterString(p.title),
 		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
@@ -497,8 +497,8 @@ func (p *LineXYPlot) Offset(offset int) *LineXYPlot {
 
 // Plot implements Plot interface.
 func (p *LineXYPlot) Plot() {
-	implot.PlotSetAxis(implot.PlotAxisEnum(p.yAxis))
-	implot.PlotPlotLinedoublePtrdoublePtrV(
+	implot.SetAxis(implot.AxisEnum(p.yAxis))
+	implot.PlotLinedoublePtrdoublePtrV(
 		Context.FontAtlas.RegisterString(p.title),
 		utils.SliceToPtr(p.xs),
 		utils.SliceToPtr(p.ys),
@@ -554,12 +554,12 @@ func (p *PieChartPlot) Angle0(a float64) *PieChartPlot {
 
 // Plot implements Plot interface.
 func (p *PieChartPlot) Plot() {
-	var flags implot.PlotPieChartFlags
+	var flags implot.PieChartFlags
 	if p.normalize {
-		flags |= implot.PlotPieChartFlagsNormalize
+		flags |= implot.PieChartFlagsNormalize
 	}
 
-	implot.PlotPlotPieChartdoublePtrStrV(
+	implot.PlotPieChartdoublePtrStrV(
 		Context.FontAtlas.RegisterStringSlice(p.labels),
 		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
@@ -611,7 +611,7 @@ func (p *ScatterPlot) Offset(offset int) *ScatterPlot {
 
 // Plot implements Plot interface.
 func (p *ScatterPlot) Plot() {
-	implot.PlotPlotScatterdoublePtrIntV(
+	implot.PlotScatterdoublePtrIntV(
 		Context.FontAtlas.RegisterString(p.label),
 		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
@@ -648,7 +648,7 @@ func (p *ScatterXYPlot) Offset(offset int) *ScatterXYPlot {
 
 // Plot implements Plot interface.
 func (p *ScatterXYPlot) Plot() {
-	implot.PlotPlotScatterdoublePtrdoublePtrV(
+	implot.PlotScatterdoublePtrdoublePtrV(
 		Context.FontAtlas.RegisterString(p.label),
 		utils.SliceToPtr(p.xs),
 		utils.SliceToPtr(p.ys),

--- a/StyleIDs.go
+++ b/StyleIDs.go
@@ -170,27 +170,27 @@ type StylePlotColorID int
 
 // List of plot color IDs.
 const (
-	StylePlotColorLine          StylePlotColorID = StylePlotColorID(implot.PlotColLine)          // plot-line
-	StylePlotColorFill          StylePlotColorID = StylePlotColorID(implot.PlotColFill)          // plot-fill
-	StylePlotColorMarkerOutline StylePlotColorID = StylePlotColorID(implot.PlotColMarkerOutline) // plot-marker-outline
-	StylePlotColorMarkerFill    StylePlotColorID = StylePlotColorID(implot.PlotColMarkerFill)    // plot-Marker-Fill
-	StylePlotColorErrorBar      StylePlotColorID = StylePlotColorID(implot.PlotColErrorBar)      // plot-error-bar
-	StylePlotColorFrameBg       StylePlotColorID = StylePlotColorID(implot.PlotColFrameBg)       // plot-frame-bg
-	StylePlotColorPlotBg        StylePlotColorID = StylePlotColorID(implot.PlotColPlotBg)        // plot-plot-bg
-	StylePlotColorPlotBorder    StylePlotColorID = StylePlotColorID(implot.PlotColPlotBorder)    // plot-plot-border
-	StylePlotColorLegendBg      StylePlotColorID = StylePlotColorID(implot.PlotColLegendBg)      // plot-legend-bg
-	StylePlotColorLegendBorder  StylePlotColorID = StylePlotColorID(implot.PlotColLegendBorder)  // plot-legend-border
-	StylePlotColorLegendText    StylePlotColorID = StylePlotColorID(implot.PlotColLegendText)    // plot-legend-text
-	StylePlotColorTitleText     StylePlotColorID = StylePlotColorID(implot.PlotColTitleText)     // plot-title-text
-	StylePlotColorInlayText     StylePlotColorID = StylePlotColorID(implot.PlotColInlayText)     // plot-inlay-text
-	StylePlotColorAxisText      StylePlotColorID = StylePlotColorID(implot.PlotColAxisText)      // plot-axis-text
-	StylePlotColorAxisGrid      StylePlotColorID = StylePlotColorID(implot.PlotColAxisGrid)      // plot-axis-grid
-	StylePlotColorAxisTick      StylePlotColorID = StylePlotColorID(implot.PlotColAxisTick)      // plot-axis-tick
-	StylePlotColorAxisBg        StylePlotColorID = StylePlotColorID(implot.PlotColAxisBg)        // plot-axis-bg
-	StylePlotColorAxisBgHovered StylePlotColorID = StylePlotColorID(implot.PlotColAxisBgHovered) // plot-axis-bg-hovered
-	StylePlotColorAxisBgActive  StylePlotColorID = StylePlotColorID(implot.PlotColAxisBgActive)  // plot-axis-bg-active
-	StylePlotColorSelection     StylePlotColorID = StylePlotColorID(implot.PlotColSelection)     // plot-selection
-	StylePlotColorCrosshairs    StylePlotColorID = StylePlotColorID(implot.PlotColCrosshairs)    // plot-crosshairs
+	StylePlotColorLine          StylePlotColorID = StylePlotColorID(implot.ColLine)          // plot-line
+	StylePlotColorFill          StylePlotColorID = StylePlotColorID(implot.ColFill)          // plot-fill
+	StylePlotColorMarkerOutline StylePlotColorID = StylePlotColorID(implot.ColMarkerOutline) // plot-marker-outline
+	StylePlotColorMarkerFill    StylePlotColorID = StylePlotColorID(implot.ColMarkerFill)    // plot-Marker-Fill
+	StylePlotColorErrorBar      StylePlotColorID = StylePlotColorID(implot.ColErrorBar)      // plot-error-bar
+	StylePlotColorFrameBg       StylePlotColorID = StylePlotColorID(implot.ColFrameBg)       // plot-frame-bg
+	StylePlotColorPlotBg        StylePlotColorID = StylePlotColorID(implot.ColPlotBg)        // plot-plot-bg
+	StylePlotColorPlotBorder    StylePlotColorID = StylePlotColorID(implot.ColPlotBorder)    // plot-plot-border
+	StylePlotColorLegendBg      StylePlotColorID = StylePlotColorID(implot.ColLegendBg)      // plot-legend-bg
+	StylePlotColorLegendBorder  StylePlotColorID = StylePlotColorID(implot.ColLegendBorder)  // plot-legend-border
+	StylePlotColorLegendText    StylePlotColorID = StylePlotColorID(implot.ColLegendText)    // plot-legend-text
+	StylePlotColorTitleText     StylePlotColorID = StylePlotColorID(implot.ColTitleText)     // plot-title-text
+	StylePlotColorInlayText     StylePlotColorID = StylePlotColorID(implot.ColInlayText)     // plot-inlay-text
+	StylePlotColorAxisText      StylePlotColorID = StylePlotColorID(implot.ColAxisText)      // plot-axis-text
+	StylePlotColorAxisGrid      StylePlotColorID = StylePlotColorID(implot.ColAxisGrid)      // plot-axis-grid
+	StylePlotColorAxisTick      StylePlotColorID = StylePlotColorID(implot.ColAxisTick)      // plot-axis-tick
+	StylePlotColorAxisBg        StylePlotColorID = StylePlotColorID(implot.ColAxisBg)        // plot-axis-bg
+	StylePlotColorAxisBgHovered StylePlotColorID = StylePlotColorID(implot.ColAxisBgHovered) // plot-axis-bg-hovered
+	StylePlotColorAxisBgActive  StylePlotColorID = StylePlotColorID(implot.ColAxisBgActive)  // plot-axis-bg-active
+	StylePlotColorSelection     StylePlotColorID = StylePlotColorID(implot.ColSelection)     // plot-selection
+	StylePlotColorCrosshairs    StylePlotColorID = StylePlotColorID(implot.ColCrosshairs)    // plot-crosshairs
 )
 
 // StylePlotVarID represents an ID of plot style variable.
@@ -198,34 +198,34 @@ type StylePlotVarID imgui.StyleVar
 
 // List of plot style variable IDs.
 const (
-	StylePlotVarLineWeight         StylePlotVarID = StylePlotVarID(implot.PlotStyleVarLineWeight)         // plot-line-weight
-	StylePlotVarMarker             StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMarker)             // plot-marker
-	StylePlotVarMarkerSize         StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMarkerSize)         // plot-marker-size
-	StylePlotVarMarkerWeight       StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMarkerWeight)       // plot-marker-weight
-	StylePlotVarFillAlpha          StylePlotVarID = StylePlotVarID(implot.PlotStyleVarFillAlpha)          // plot-fill-alpha
-	StylePlotVarErrorBarSize       StylePlotVarID = StylePlotVarID(implot.PlotStyleVarErrorBarSize)       // plot-error-bar-size
-	StylePlotVarErrorBarWeight     StylePlotVarID = StylePlotVarID(implot.PlotStyleVarErrorBarWeight)     // plot-error-bar-weight
-	StylePlotVarDigitalBitHeight   StylePlotVarID = StylePlotVarID(implot.PlotStyleVarDigitalBitHeight)   // plot-digital-bit-height
-	StylePlotVarDigitalBitGap      StylePlotVarID = StylePlotVarID(implot.PlotStyleVarDigitalBitGap)      // plot-digital-bit-gap
-	StylePlotVarPlotBorderSize     StylePlotVarID = StylePlotVarID(implot.PlotStyleVarPlotBorderSize)     // plot-border-size
-	StylePlotVarMinorAlpha         StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMinorAlpha)         // plot-minor-alpha
-	StylePlotVarMajorTickLen       StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMajorTickLen)       // plot-major-tick-len
-	StylePlotVarMinorTickLen       StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMinorTickLen)       // plot-minor-tick-len
-	StylePlotVarMajorTickSize      StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMajorTickSize)      // plot-major-tick-size
-	StylePlotVarMinorTickSize      StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMinorTickSize)      // plot-minor-tick-size
-	StylePlotVarMajorGridSize      StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMajorGridSize)      // plot-major-grid-size
-	StylePlotVarMinorGridSize      StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMinorGridSize)      // plot-minor-grid-size
-	StylePlotVarPlotPadding        StylePlotVarID = StylePlotVarID(implot.PlotStyleVarPlotPadding)        // plot-padding
-	StylePlotVarLabelPadding       StylePlotVarID = StylePlotVarID(implot.PlotStyleVarLabelPadding)       // plot-label-padding
-	StylePlotVarLegendPadding      StylePlotVarID = StylePlotVarID(implot.PlotStyleVarLegendPadding)      // plot-legend-padding
-	StylePlotVarLegendInnerPadding StylePlotVarID = StylePlotVarID(implot.PlotStyleVarLegendInnerPadding) // plot-legend-inner-padding
-	StylePlotVarLegendSpacing      StylePlotVarID = StylePlotVarID(implot.PlotStyleVarLegendSpacing)      // plot-legend-spacing
-	StylePlotVarMousePosPadding    StylePlotVarID = StylePlotVarID(implot.PlotStyleVarMousePosPadding)    // plot-mouse-pos-padding
-	StylePlotVarAnnotationPadding  StylePlotVarID = StylePlotVarID(implot.PlotStyleVarAnnotationPadding)  // plot-annotation-padding
-	StylePlotVarFitPadding         StylePlotVarID = StylePlotVarID(implot.PlotStyleVarFitPadding)         // plot-fit-padding
-	StylePlotVarPlotDefaultSize    StylePlotVarID = StylePlotVarID(implot.PlotStyleVarPlotDefaultSize)    // plot-default-size
-	StylePlotVarPlotMinSize        StylePlotVarID = StylePlotVarID(implot.PlotStyleVarPlotMinSize)        // plot-min-size
-	StylePlotVarCOUNT              StylePlotVarID = StylePlotVarID(implot.PlotStyleVarCOUNT)
+	StylePlotVarLineWeight         StylePlotVarID = StylePlotVarID(implot.StyleVarLineWeight)         // plot-line-weight
+	StylePlotVarMarker             StylePlotVarID = StylePlotVarID(implot.StyleVarMarker)             // plot-marker
+	StylePlotVarMarkerSize         StylePlotVarID = StylePlotVarID(implot.StyleVarMarkerSize)         // plot-marker-size
+	StylePlotVarMarkerWeight       StylePlotVarID = StylePlotVarID(implot.StyleVarMarkerWeight)       // plot-marker-weight
+	StylePlotVarFillAlpha          StylePlotVarID = StylePlotVarID(implot.StyleVarFillAlpha)          // plot-fill-alpha
+	StylePlotVarErrorBarSize       StylePlotVarID = StylePlotVarID(implot.StyleVarErrorBarSize)       // plot-error-bar-size
+	StylePlotVarErrorBarWeight     StylePlotVarID = StylePlotVarID(implot.StyleVarErrorBarWeight)     // plot-error-bar-weight
+	StylePlotVarDigitalBitHeight   StylePlotVarID = StylePlotVarID(implot.StyleVarDigitalBitHeight)   // plot-digital-bit-height
+	StylePlotVarDigitalBitGap      StylePlotVarID = StylePlotVarID(implot.StyleVarDigitalBitGap)      // plot-digital-bit-gap
+	StylePlotVarPlotBorderSize     StylePlotVarID = StylePlotVarID(implot.StyleVarPlotBorderSize)     // plot-border-size
+	StylePlotVarMinorAlpha         StylePlotVarID = StylePlotVarID(implot.StyleVarMinorAlpha)         // plot-minor-alpha
+	StylePlotVarMajorTickLen       StylePlotVarID = StylePlotVarID(implot.StyleVarMajorTickLen)       // plot-major-tick-len
+	StylePlotVarMinorTickLen       StylePlotVarID = StylePlotVarID(implot.StyleVarMinorTickLen)       // plot-minor-tick-len
+	StylePlotVarMajorTickSize      StylePlotVarID = StylePlotVarID(implot.StyleVarMajorTickSize)      // plot-major-tick-size
+	StylePlotVarMinorTickSize      StylePlotVarID = StylePlotVarID(implot.StyleVarMinorTickSize)      // plot-minor-tick-size
+	StylePlotVarMajorGridSize      StylePlotVarID = StylePlotVarID(implot.StyleVarMajorGridSize)      // plot-major-grid-size
+	StylePlotVarMinorGridSize      StylePlotVarID = StylePlotVarID(implot.StyleVarMinorGridSize)      // plot-minor-grid-size
+	StylePlotVarPlotPadding        StylePlotVarID = StylePlotVarID(implot.StyleVarPlotPadding)        // plot-padding
+	StylePlotVarLabelPadding       StylePlotVarID = StylePlotVarID(implot.StyleVarLabelPadding)       // plot-label-padding
+	StylePlotVarLegendPadding      StylePlotVarID = StylePlotVarID(implot.StyleVarLegendPadding)      // plot-legend-padding
+	StylePlotVarLegendInnerPadding StylePlotVarID = StylePlotVarID(implot.StyleVarLegendInnerPadding) // plot-legend-inner-padding
+	StylePlotVarLegendSpacing      StylePlotVarID = StylePlotVarID(implot.StyleVarLegendSpacing)      // plot-legend-spacing
+	StylePlotVarMousePosPadding    StylePlotVarID = StylePlotVarID(implot.StyleVarMousePosPadding)    // plot-mouse-pos-padding
+	StylePlotVarAnnotationPadding  StylePlotVarID = StylePlotVarID(implot.StyleVarAnnotationPadding)  // plot-annotation-padding
+	StylePlotVarFitPadding         StylePlotVarID = StylePlotVarID(implot.StyleVarFitPadding)         // plot-fit-padding
+	StylePlotVarPlotDefaultSize    StylePlotVarID = StylePlotVarID(implot.StyleVarPlotDefaultSize)    // plot-default-size
+	StylePlotVarPlotMinSize        StylePlotVarID = StylePlotVarID(implot.StyleVarPlotMinSize)        // plot-min-size
+	StylePlotVarCOUNT              StylePlotVarID = StylePlotVarID(implot.StyleVarCOUNT)
 )
 
 // IsVec2 returns true if the style plot var id should be processed as imgui.Vec2

--- a/StyleSetter.go
+++ b/StyleSetter.go
@@ -203,7 +203,7 @@ func (ss *StyleSetter) Push() {
 
 	// Push plot colors
 	for k, v := range ss.plotColors {
-		implot.PlotPushStyleColorVec4(implot.PlotCol(k), ToVec4Color(v))
+		implot.PushStyleColorVec4(implot.Col(k), ToVec4Color(v))
 	}
 
 	// push style vars
@@ -218,9 +218,9 @@ func (ss *StyleSetter) Push() {
 	// Push plot colors
 	for k, v := range ss.plotStyles {
 		pushVarID(k.IsVec2(), v, func(value float32) {
-			implot.PlotPushStyleVarFloat(implot.PlotStyleVar(k), value)
+			implot.PushStyleVarFloat(implot.StyleVar(k), value)
 		}, func(value imgui.Vec2) {
-			implot.PlotPushStyleVarVec2(implot.PlotStyleVar(k), value)
+			implot.PushStyleVarVec2(implot.StyleVar(k), value)
 		})
 	}
 
@@ -245,9 +245,9 @@ func (ss *StyleSetter) Pop() {
 	}
 
 	imgui.PopStyleColorV(int32(len(ss.colors)))
-	implot.PlotPopStyleColorV(int32(len(ss.plotColors)))
+	implot.PopStyleColorV(int32(len(ss.plotColors)))
 	imgui.PopStyleVarV(int32(len(ss.styles)))
-	implot.PlotPopStyleVarV(int32(len(ss.plotStyles)))
+	implot.PopStyleVarV(int32(len(ss.plotStyles)))
 }
 
 func pushVarID(isVec2 bool, v any, pushFloat func(float32), pushVec2 func(imgui.Vec2)) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AllenDang/giu
 go 1.23.2
 
 require (
-	github.com/AllenDang/cimgui-go v1.1.0
+	github.com/AllenDang/cimgui-go v1.1.1-0.20241105214716-82a5c1ae9712
 	github.com/AllenDang/go-findfont v0.0.0-20200702051237-9f180485aeb8
 	github.com/faiface/mainthread v0.0.0-20171120011319-8b78f0a41ae3
 	github.com/mazznoer/csscolorparser v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/AllenDang/cimgui-go v1.1.0 h1:hltblxjy6Q+/TxOQLjI45yVlCn/DQSC9DLTtKc8PhfQ=
 github.com/AllenDang/cimgui-go v1.1.0/go.mod h1:v5iftKz+rJRG6TArxibxqqOhVqUyzMkqbX90iC2Mqe0=
+github.com/AllenDang/cimgui-go v1.1.1-0.20241105214716-82a5c1ae9712 h1:Qog9ZG14NbkuzbqzwT7zX9u+yi1fTU8ZIlesefYmc40=
+github.com/AllenDang/cimgui-go v1.1.1-0.20241105214716-82a5c1ae9712/go.mod h1:/gM0PosnwlgK0Fc3UFALXWPEIu+cW2DC3YU0Z4EwV2Y=
 github.com/AllenDang/go-findfont v0.0.0-20200702051237-9f180485aeb8 h1:dKZMqib/yUDoCFigmz2agG8geZ/e3iRq304/KJXqKyw=
 github.com/AllenDang/go-findfont v0.0.0-20200702051237-9f180485aeb8/go.mod h1:b4uuDd0s6KRIPa84cEEchdQ9ICh7K0OryZHbSzMca9k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
in the latest commit in cimgui-go we've updated some function names.

I introduce them in giu asap to avoid loses of my time later.

Applied with this:
```go
sed -i -e 's/implot\.Plot/implot\./g' -e 's/imnodes\.ImNodes/imnodes\./g' *go
```