### PR TITLE
readme: do not recommend tdm-gcc anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,6 @@ go get github.com/AllenDang/giu
 2. Add the binaries folder of mingw to the path (usually is _\mingw64\bin_).
 3. go get github.com/AllenDang/giu
 
-Or, install [TDM-GCC](https://jmeubank.github.io/tdm-gcc/).
-
 ### Linux
 
 First you need to install the required dependencies:


### PR DESCRIPTION
TDM-GCC is https://github.com/jmeubank/tdm-gcc.
The current version of gcc provided by the project is 10.3.0. According to https://github.com/jmeubank/tdm-gcc/issues/68 I think the project was discontinued.

According to https://github.com/AllenDang/giu/issues/911 we are forced to stop recommending tdm-gcc for giu.