### PR TITLE
Clickable widget: push auto ids

### DIFF
--- a/ClickableWidgets.go
+++ b/ClickableWidgets.go
@@ -225,6 +225,7 @@ func ImageButton(texture *Texture) *ImageButtonWidget {
 	}
 }
 
+// ID allows to manually set widget's id.
 func (b *ImageButtonWidget) ID(id ID) *ImageButtonWidget {
 	b.id = id
 	return b

--- a/ClickableWidgets.go
+++ b/ClickableWidgets.go
@@ -206,6 +206,7 @@ type ImageButtonWidget struct {
 	bgColor      color.Color
 	tintColor    color.Color
 	onClick      func()
+	id           ID
 }
 
 // ImageButton  constructs image button widget.
@@ -220,7 +221,13 @@ func ImageButton(texture *Texture) *ImageButtonWidget {
 		bgColor:      colornames.Black,
 		tintColor:    colornames.White,
 		onClick:      nil,
+		id:           GenAutoID("ImageButton"),
 	}
+}
+
+func (b *ImageButtonWidget) ID(id ID) *ImageButtonWidget {
+	b.id = id
+	return b
 }
 
 // Build implements Widget interface.
@@ -229,6 +236,7 @@ func (b *ImageButtonWidget) Build() {
 		return
 	}
 
+	imgui.PushIDStr(b.id.String())
 	if imgui.ImageButtonV(
 		fmt.Sprintf("%v", b.texture.tex.ID),
 		b.texture.tex.ID,
@@ -239,6 +247,8 @@ func (b *ImageButtonWidget) Build() {
 	) && b.onClick != nil {
 		b.onClick()
 	}
+
+	imgui.PopID()
 }
 
 // Size sets BUTTONS size.

--- a/ClickableWidgets.go
+++ b/ClickableWidgets.go
@@ -238,6 +238,7 @@ func (b *ImageButtonWidget) Build() {
 	}
 
 	imgui.PushIDStr(b.id.String())
+
 	if imgui.ImageButtonV(
 		fmt.Sprintf("%v", b.texture.tex.ID),
 		b.texture.tex.ID,


### PR DESCRIPTION
I've just noticed that 2 ImageButton's with the same texture are conflicting items for imgui. Now ImageButton auto-generates and ID and adds ID method if someone wants to set the ID manually