### PR TITLE
fix(InvisibleButton): Set default size to -1, -1

### DIFF
--- a/ClickableWidgets.go
+++ b/ClickableWidgets.go
@@ -162,8 +162,8 @@ type InvisibleButtonWidget struct {
 func InvisibleButton() *InvisibleButtonWidget {
 	return &InvisibleButtonWidget{
 		id:      GenAutoID("InvisibleButton"),
-		width:   0,
-		height:  0,
+		width:   Auto,
+		height:  Auto,
 		onClick: nil,
 	}
 }


### PR DESCRIPTION
I have no idea why someone would create this button with its default size but doing that caused immediate programm crash (0-size assertion)

Generally the default size could be any random number different from 0 but -1 (aka Auto) sounds reasonable