### PR TITLE
Transparent example: makes frameless windows movable

### DIFF
--- a/examples/transparent/transparent.go
+++ b/examples/transparent/transparent.go
@@ -21,12 +21,15 @@ func FramelessMovableWidget(widget g.Widget) *g.CustomWidget {
 			isMovingFrame = false
 			return
 		}
+
 		widget.Build()
+
 		if g.IsItemHovered() {
 			if g.IsMouseDown(g.MouseButtonLeft) {
 				isMovingFrame = true
 			}
 		}
+
 		if isMovingFrame {
 			delta := imgui.CurrentIO().MouseDelta()
 			dx := int(delta.X)

--- a/examples/transparent/transparent.go
+++ b/examples/transparent/transparent.go
@@ -10,11 +10,43 @@ import (
 	g "github.com/AllenDang/giu"
 )
 
+var (
+	wnd           *g.MasterWindow
+	isMovingFrame = false
+)
+
+func FramelessMovableWidget(widget g.Widget) *g.CustomWidget {
+	return g.Custom(func() {
+		if isMovingFrame && !g.IsMouseDown(g.MouseButtonLeft) {
+			isMovingFrame = false
+			return
+		}
+		widget.Build()
+		if g.IsItemHovered() {
+			if g.IsMouseDown(g.MouseButtonLeft) {
+				isMovingFrame = true
+			}
+		}
+		if isMovingFrame {
+			delta := imgui.CurrentIO().MouseDelta()
+			dx := int(delta.X)
+			dy := int(delta.Y)
+			if dx != 0 || dy != 0 {
+				ox, oy := wnd.GetPos()
+				wnd.SetPos(ox+dx, oy+dy)
+			}
+		}
+	})
+}
+
 func loop() {
 	imgui.PushStyleVarFloat(imgui.StyleVarWindowBorderSize, 0)
-	g.PushColorWindowBg(color.RGBA{50, 50, 50, 0})
-	g.PushColorFrameBg(color.RGBA{10, 10, 10, 0})
+	g.PushColorWindowBg(color.RGBA{50, 50, 70, 130})
+	g.PushColorFrameBg(color.RGBA{30, 30, 60, 110})
 	g.SingleWindow().Layout(
+		FramelessMovableWidget(
+			g.Label("Maintain Left-click on me to move the frameless window !"),
+		),
 		g.Custom(func() {
 			canvas := g.GetCanvas()
 			pos := g.GetCursorScreenPos()
@@ -48,7 +80,8 @@ func loop() {
 }
 
 func main() {
-	wnd := g.NewMasterWindow("transparent", 300, 200, g.MasterWindowFlagsNotResizable|g.MasterWindowFlagsFloating|g.MasterWindowFlagsFrameless|g.MasterWindowFlagsTransparent)
+	wnd = g.NewMasterWindow("transparent", 300, 200, g.MasterWindowFlagsNotResizable|g.MasterWindowFlagsFloating|g.MasterWindowFlagsFrameless|g.MasterWindowFlagsTransparent)
 	wnd.SetBgColor(color.RGBA{0, 0, 0, 0})
+	wnd.SetPos(50, 50)
 	wnd.Run(loop)
 }

--- a/examples/transparent/transparent.go
+++ b/examples/transparent/transparent.go
@@ -15,7 +15,7 @@ var (
 	isMovingFrame = false
 )
 
-func FramelessMovableWidget(widget g.Widget) *g.CustomWidget {
+func framelessMovableWidget(widget g.Widget) *g.CustomWidget {
 	return g.Custom(func() {
 		if isMovingFrame && !g.IsMouseDown(g.MouseButtonLeft) {
 			isMovingFrame = false
@@ -34,6 +34,7 @@ func FramelessMovableWidget(widget g.Widget) *g.CustomWidget {
 			delta := imgui.CurrentIO().MouseDelta()
 			dx := int(delta.X)
 			dy := int(delta.Y)
+
 			if dx != 0 || dy != 0 {
 				ox, oy := wnd.GetPos()
 				wnd.SetPos(ox+dx, oy+dy)
@@ -47,7 +48,7 @@ func loop() {
 	g.PushColorWindowBg(color.RGBA{50, 50, 70, 130})
 	g.PushColorFrameBg(color.RGBA{30, 30, 60, 110})
 	g.SingleWindow().Layout(
-		FramelessMovableWidget(
+		framelessMovableWidget(
 			g.Label("Maintain Left-click on me to move the frameless window !"),
 		),
 		g.Custom(func() {


### PR DESCRIPTION
 with simple implementation

![movableFrame](https://github.com/user-attachments/assets/339ea5ed-8c4c-46d5-940f-a0e1aa2a381e)
