### PR TITLE
Added Filter to ComboWidget

### DIFF
--- a/examples/widgets/widgets.go
+++ b/examples/widgets/widgets.go
@@ -120,6 +120,7 @@ func loop() {
 		),
 
 		g.Combo("Combo", items[itemSelected], items, &itemSelected).OnChange(comboChanged),
+		g.Combo("Combo (w/ filter)", items[itemSelected], items, &itemSelected).OnChange(comboChanged).Filter(true),
 
 		g.ColorEdit("<- Click the black square. I'm changing a color for you##colorChanger", col).
 			Size(100).


### PR DESCRIPTION
In examples/imguidemo, there is a combo box with a filter. It sadly doesn't seem to exist currently, creating quite a false-promise. So, I went to the original imgui repo and took the [code from there](https://github.com/ocornut/imgui/blob/5679de60c567fc62c091004ee80a738757e6d3b6/imgui_demo.cpp#L1318-L1339) to create a `Filter` method on the `ComboWidget`, specifying if there should be a TextFilter when opening it.