### PR TITLE
Drag widgets rework

### DIFF
--- a/SliderWidgets.go
+++ b/SliderWidgets.go
@@ -333,3 +333,91 @@ func (d *DragIntWidget) Build() {
 		d.onChange()
 	}
 }
+
+var _ Widget = &DragFloatWidget{}
+
+// DragFloatWidget is like DragIntWidget but for float32 values.
+type DragFloatWidget struct {
+	label    ID
+	value    *float32
+	speed    float32
+	minValue float32
+	maxValue float32
+	format   string
+	onChange func()
+	flags    SliderFlags
+}
+
+// DragFloat creates new DragFloatWidget.
+func DragFloat(value *float32) *DragFloatWidget {
+	return &DragFloatWidget{
+		label:    GenAutoID("##DragFloat"),
+		value:    value,
+		speed:    1.0,
+		minValue: 0,
+		maxValue: 0,
+		format:   "%d",
+	}
+}
+
+// Label allows to set widgets label.
+// IMPORTANT: label uses AutoID mechanism so your label should not be unique.
+func (d *DragFloatWidget) Label(label string) *DragFloatWidget {
+	d.label = GenAutoID(label)
+	return d
+}
+
+// Labelf sets formatted label.
+func (d *DragFloatWidget) Labelf(format string, args ...any) *DragFloatWidget {
+	return d.Label(fmt.Sprintf(format, args...))
+}
+
+// ID manually sets widget id.
+// This must be unique - use Label if you can.
+func (d *DragFloatWidget) ID(id ID) *DragFloatWidget {
+	d.label = id
+	return d
+}
+
+// Speed sets speed of the dragging.
+func (d *DragFloatWidget) Speed(speed float32) *DragFloatWidget {
+	d.speed = speed
+	return d
+}
+
+// MinValue sets minimum value of the drag.
+func (d *DragFloatWidget) MinValue(minValue float32) *DragFloatWidget {
+	d.minValue = minValue
+	return d
+}
+
+// MaxValue sets maximum value of the drag.
+func (d *DragFloatWidget) MaxValue(maxValue float32) *DragFloatWidget {
+	d.maxValue = maxValue
+	return d
+}
+
+// Format sets format of the value.
+func (d *DragFloatWidget) Format(format string) *DragFloatWidget {
+	d.format = format
+	return d
+}
+
+// Flags allows to set flags (in form of SliderFlags) for the Drag Int widget.
+func (d *DragFloatWidget) Flags(f SliderFlags) *DragFloatWidget {
+	d.flags = f
+	return d
+}
+
+// OnChange sets callback that will be executed when value is changed.
+func (d *DragFloatWidget) OnChange(onChange func()) *DragFloatWidget {
+	d.onChange = onChange
+	return d
+}
+
+// Build implements Widget interface.
+func (d *DragFloatWidget) Build() {
+	if imgui.DragFloatV(Context.FontAtlas.RegisterString(d.label.String()), d.value, d.speed, d.minValue, d.maxValue, d.format, imgui.SliderFlags(d.flags)) && d.onChange != nil {
+		d.onChange()
+	}
+}

--- a/SliderWidgets.go
+++ b/SliderWidgets.go
@@ -244,3 +244,51 @@ func (sf *SliderFloatWidget) Build() {
 		sf.onChange()
 	}
 }
+
+// DragIntWidget is a widget that allows to drag an integer value.
+type DragIntWidget struct {
+	label    ID
+	value    *int32
+	speed    float32
+	minValue int32
+	maxValue int32
+	format   string
+	onChange func()
+}
+
+// DragInt creates new DragIntWidget.
+func DragInt(label string, value *int32, minValue, maxValue int32) *DragIntWidget {
+	return &DragIntWidget{
+		label:    GenAutoID(label),
+		value:    value,
+		speed:    1.0,
+		minValue: minValue,
+		maxValue: maxValue,
+		format:   "%d",
+	}
+}
+
+// Speed sets speed of the dragging.
+func (d *DragIntWidget) Speed(speed float32) *DragIntWidget {
+	d.speed = speed
+	return d
+}
+
+// Format sets format of the value.
+func (d *DragIntWidget) Format(format string) *DragIntWidget {
+	d.format = format
+	return d
+}
+
+// OnChange sets callback that will be executed when value is changed.
+func (d *DragIntWidget) OnChange(onChange func()) *DragIntWidget {
+	d.onChange = onChange
+	return d
+}
+
+// Build implements Widget interface.
+func (d *DragIntWidget) Build() {
+	if imgui.DragIntV(Context.FontAtlas.RegisterString(d.label.String()), d.value, d.speed, d.minValue, d.maxValue, d.format, 0) && d.onChange != nil {
+		d.onChange()
+	}
+}

--- a/SliderWidgets.go
+++ b/SliderWidgets.go
@@ -254,6 +254,7 @@ type DragIntWidget struct {
 	maxValue int32
 	format   string
 	onChange func()
+	flags    SliderFlags
 }
 
 // DragInt creates new DragIntWidget.
@@ -280,6 +281,12 @@ func (d *DragIntWidget) Format(format string) *DragIntWidget {
 	return d
 }
 
+// Flags allows to set flags (in form of SliderFlags) for the Drag Int widget.
+func (d *DragIntWidget) Flags(f SliderFlags) *DragIntWidget {
+	d.flags = f
+	return d
+}
+
 // OnChange sets callback that will be executed when value is changed.
 func (d *DragIntWidget) OnChange(onChange func()) *DragIntWidget {
 	d.onChange = onChange
@@ -288,7 +295,7 @@ func (d *DragIntWidget) OnChange(onChange func()) *DragIntWidget {
 
 // Build implements Widget interface.
 func (d *DragIntWidget) Build() {
-	if imgui.DragIntV(Context.FontAtlas.RegisterString(d.label.String()), d.value, d.speed, d.minValue, d.maxValue, d.format, 0) && d.onChange != nil {
+	if imgui.DragIntV(Context.FontAtlas.RegisterString(d.label.String()), d.value, d.speed, d.minValue, d.maxValue, d.format, imgui.SliderFlags(d.flags)) && d.onChange != nil {
 		d.onChange()
 	}
 }

--- a/SliderWidgets.go
+++ b/SliderWidgets.go
@@ -245,6 +245,8 @@ func (sf *SliderFloatWidget) Build() {
 	}
 }
 
+var _ Widget = &DragIntWidget{}
+
 // DragIntWidget is a widget similar to SliderWidget, does not have a "conventional slider".
 // Instead, you can just drag the value left/right to change it.
 type DragIntWidget struct {
@@ -259,13 +261,13 @@ type DragIntWidget struct {
 }
 
 // DragInt creates new DragIntWidget.
-func DragInt(value *int32, minValue, maxValue int32) *DragIntWidget {
+func DragInt(value *int32) *DragIntWidget {
 	return &DragIntWidget{
 		label:    GenAutoID("##DragInt"),
 		value:    value,
 		speed:    1.0,
-		minValue: minValue,
-		maxValue: maxValue,
+		minValue: 0,
+		maxValue: 0,
 		format:   "%d",
 	}
 }
@@ -292,6 +294,18 @@ func (d *DragIntWidget) ID(id ID) *DragIntWidget {
 // Speed sets speed of the dragging.
 func (d *DragIntWidget) Speed(speed float32) *DragIntWidget {
 	d.speed = speed
+	return d
+}
+
+// MinValue sets minimum value of the drag.
+func (d *DragIntWidget) MinValue(minValue int32) *DragIntWidget {
+	d.minValue = minValue
+	return d
+}
+
+// MaxValue sets maximum value of the drag.
+func (d *DragIntWidget) MaxValue(maxValue int32) *DragIntWidget {
+	d.maxValue = maxValue
 	return d
 }
 

--- a/SliderWidgets.go
+++ b/SliderWidgets.go
@@ -259,15 +259,34 @@ type DragIntWidget struct {
 }
 
 // DragInt creates new DragIntWidget.
-func DragInt(label string, value *int32, minValue, maxValue int32) *DragIntWidget {
+func DragInt(value *int32, minValue, maxValue int32) *DragIntWidget {
 	return &DragIntWidget{
-		label:    GenAutoID(label),
+		label:    GenAutoID("##DragInt"),
 		value:    value,
 		speed:    1.0,
 		minValue: minValue,
 		maxValue: maxValue,
 		format:   "%d",
 	}
+}
+
+// Label allows to set widgets label.
+// IMPORTANT: label uses AutoID mechanism so your label should not be unique.
+func (d *DragIntWidget) Label(label string) *DragIntWidget {
+	d.label = GenAutoID(label)
+	return d
+}
+
+// Labelf sets formatted label.
+func (d *DragIntWidget) Labelf(format string, args ...any) *DragIntWidget {
+	return d.Label(fmt.Sprintf(format, args...))
+}
+
+// ID manually sets widget id.
+// This must be unique - use Label if you can.
+func (d *DragIntWidget) ID(id ID) *DragIntWidget {
+	d.label = id
+	return d
 }
 
 // Speed sets speed of the dragging.

--- a/SliderWidgets.go
+++ b/SliderWidgets.go
@@ -245,7 +245,8 @@ func (sf *SliderFloatWidget) Build() {
 	}
 }
 
-// DragIntWidget is a widget that allows to drag an integer value.
+// DragIntWidget is a widget similar to SliderWidget, does not have a "conventional slider".
+// Instead, you can just drag the value left/right to change it.
 type DragIntWidget struct {
 	label    ID
 	value    *int32

--- a/Widgets.go
+++ b/Widgets.go
@@ -294,8 +294,6 @@ func (c *ContextMenuWidget) Build() {
 	}
 }
 
-var _ Widget = &DragIntWidget{}
-
 var _ Widget = &ColumnWidget{}
 
 // ColumnWidget will place all widgets one by one vertically.

--- a/Widgets.go
+++ b/Widgets.go
@@ -296,54 +296,6 @@ func (c *ContextMenuWidget) Build() {
 
 var _ Widget = &DragIntWidget{}
 
-// DragIntWidget is a widget that allows to drag an integer value.
-type DragIntWidget struct {
-	label    ID
-	value    *int32
-	speed    float32
-	minValue int32
-	maxValue int32
-	format   string
-	onChange func()
-}
-
-// DragInt creates new DragIntWidget.
-func DragInt(label string, value *int32, minValue, maxValue int32) *DragIntWidget {
-	return &DragIntWidget{
-		label:    GenAutoID(label),
-		value:    value,
-		speed:    1.0,
-		minValue: minValue,
-		maxValue: maxValue,
-		format:   "%d",
-	}
-}
-
-// Speed sets speed of the dragging.
-func (d *DragIntWidget) Speed(speed float32) *DragIntWidget {
-	d.speed = speed
-	return d
-}
-
-// Format sets format of the value.
-func (d *DragIntWidget) Format(format string) *DragIntWidget {
-	d.format = format
-	return d
-}
-
-// OnChange sets callback that will be executed when value is changed.
-func (d *DragIntWidget) OnChange(onChange func()) *DragIntWidget {
-	d.onChange = onChange
-	return d
-}
-
-// Build implements Widget interface.
-func (d *DragIntWidget) Build() {
-	if imgui.DragIntV(Context.FontAtlas.RegisterString(d.label.String()), d.value, d.speed, d.minValue, d.maxValue, d.format, 0) && d.onChange != nil {
-		d.onChange()
-	}
-}
-
 var _ Widget = &ColumnWidget{}
 
 // ColumnWidget will place all widgets one by one vertically.

--- a/examples/loadimageAdvanced/loadimageAdvanced.go
+++ b/examples/loadimageAdvanced/loadimageAdvanced.go
@@ -52,8 +52,8 @@ func loop() {
 
 		g.Separator(),
 		g.Label("Advanced Drawing manipulation"),
-		g.DragInt("Sonic Offset X", &sonicOffsetX, 0, 1280),
-		g.DragInt("Sonic Offset Y", &sonicOffsetY, 0, 720),
+		g.DragInt(&sonicOffsetX).Label("Sonic Offset X").MinValue(0).MaxValue(1280),
+		g.DragInt(&sonicOffsetY).Label("Sonic Offset Y").MinValue(0).MaxValue(720),
 		g.Custom(func() {
 			size := fromurl.GetSurfaceSize()
 			sonicOffset := image.Point{int(sonicOffsetX), int(sonicOffsetY)}

--- a/examples/widgets/widgets.go
+++ b/examples/widgets/widgets.go
@@ -104,7 +104,11 @@ func loop() {
 		),
 
 		g.ProgressBar(0.8).Size(g.Auto, 0).Overlay("Progress"),
-		g.DragInt("DragInt", &dragInt, 0, 100),
+		g.DragInt(&dragInt).
+			Label("DragInt").
+			MinValue(0).
+			MaxValue(100).
+			OnChange(func() { fmt.Println(dragInt) }),
 		g.SliderInt(&dragInt, 0, 100).Label("Slider"),
 
 		g.Label("Vertical sliders"),


### PR DESCRIPTION
- move DragInt to SliderWidgets.go
- **BREAKING** remove non-mandatory arguments form the main widget's creator. Add setters instead. `s/DragInt(\(.*\),\(.*\),\(.*\),\(.*\))/DragInt(\2)\.Label(\1)\.MinValue(\3).MaxValue(\4)/g` should do the migration
- added `DragFloatWidget`