### PR TITLE
sortable-table: only run sort on sortable tables

### DIFF
--- a/TableWidgets.go
+++ b/TableWidgets.go
@@ -258,7 +258,9 @@ func (t *TableWidget) Build() {
 				imgui.TableHeadersRow()
 			}
 
-			t.handleSort()
+			if t.flags&TableFlags(imgui.TableFlagsSortable) != 0 {
+				t.handleSort()
+			}
 		}
 
 		if t.fastMode {


### PR DESCRIPTION
Fixes a SEGV when run on tables without the IsSortable Flag.