### PR TITLE
Add rangebuilder variant that accepts maps

### DIFF
--- a/ExtraWidgets.go
+++ b/ExtraWidgets.go
@@ -229,6 +229,24 @@ func RangeBuilder[S ~[]T, T any](id string, values S, builder func(int, T) Widge
 	return layout
 }
 
+func MapRangeBuilder[S map[T]U, T comparable, U any](id string, values S, builder func(T, U) Widget) Layout {
+	var layout Layout
+
+	layout = append(layout, Custom(func() { imgui.PushIDStr(id) }))
+
+	if len(values) > 0 && builder != nil {
+		for i, v := range values {
+			valueRef := v
+			widget := builder(i, valueRef)
+			layout = append(layout, widget)
+		}
+	}
+
+	layout = append(layout, Custom(func() { imgui.PopID() }))
+
+	return layout
+}
+
 type listBoxState struct {
 	selectedIndex int32
 }

--- a/ExtraWidgets.go
+++ b/ExtraWidgets.go
@@ -229,6 +229,7 @@ func RangeBuilder[S ~[]T, T any](id string, values S, builder func(int, T) Widge
 	return layout
 }
 
+// MapRangeBuilder batch creates widgets with data from the given map, according to the given function. and renders only those which are visible.
 func MapRangeBuilder[S map[T]U, T comparable, U any](id string, values S, builder func(T, U) Widget) Layout {
 	var layout Layout
 


### PR DESCRIPTION
This PR contains the code that I've been using to build over a range from a map (resolves #973), though I doubt that it is the best implementation; I didn't want to change library code when I originally wrote this.

A good alternative that I have not personally explored may be to make the regular `RangeBuilder` function generic enough to take maps as well as slices.