### PR TITLE
font atlas: do not scale font size exclusively on windows

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -310,10 +310,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 			}
 
 			// Scale font size with DPI scale factor
-			if runtime.GOOS == windows {
-				xScale, _ := Context.backend.ContentScale()
-				fontInfo.size *= xScale
-			}
+			scaleFont(&fontInfo)
 
 			if len(fontInfo.fontByte) == 0 {
 				fonts.AddFontFromFileTTFV(fontInfo.fontPath, fontInfo.size, fontConfig, ranges.Data())
@@ -340,10 +337,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 	// Add extra fonts
 	for _, fontInfo := range a.extraFonts {
 		// Scale font size with DPI scale factor
-		if runtime.GOOS == windows {
-			xScale, _ := Context.backend.ContentScale()
-			fontInfo.size *= xScale
-		}
+		scaleFont(&fontInfo)
 
 		// Store imgui.Font for PushFont
 		var f *imgui.Font
@@ -375,4 +369,9 @@ func (a *FontAtlas) rebuildFontAtlas() {
 	fonts.SetTexReady(true)
 
 	a.shouldRebuildFontAtlas = false
+}
+
+func scaleFont(fontInfo *FontInfo) {
+	xScale, _ := Context.backend.ContentScale()
+	fontInfo.size *= xScale
 }


### PR DESCRIPTION
Why linux shouldn't do that as well?

TODO(@AllenDang): why this was here? Is it so that on mac this scaling is not needed?