### PR TITLE
Making the user .ini file optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 vendor/
 
 /cmd/gmdeploy/gmdeploy
+
+# User file (imgui.ini equivalent)
+/giu.ini

--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -77,9 +77,6 @@ func NewMasterWindow(title string, width, height int, flags MasterWindowFlags) *
 	// TODO: removed io.SetConfigFlags(imgui.BackendFlagsRendererHasVtxOffset)
 	io.SetBackendFlags(imgui.BackendFlagsRendererHasVtxOffset)
 
-	// Disable imgui.ini
-	io.SetIniFilename("")
-
 	currentBackend, err := backend.CreateBackend(NewGLFWBackend())
 	if err != nil && !errors.Is(err, backend.CExposerError) {
 		panic(err)
@@ -98,6 +95,9 @@ func NewMasterWindow(title string, width, height int, flags MasterWindowFlags) *
 		ctx:        Context,
 		theme:      DefaultTheme(),
 	}
+
+	// Disable imgui.ini
+	mw.SetUserFile("")
 
 	currentBackend.SetBeforeRenderHook(mw.beforeRender)
 	currentBackend.SetAfterRenderHook(mw.afterRender)
@@ -425,4 +425,11 @@ func (w *MasterWindow) SetInputHandler(handler InputHandler) {
 // See examples/issue-501.
 func (w *MasterWindow) SetAdditionalInputHandlerCallback(cb InputHandlerHandleCallback) {
 	w.additionalInputCallback = cb
+}
+
+// SetUserFile sets the path to the .ini file which saves the user preferences (e.g. subwindow positions, table column widths, etc.).
+// Provide an empty string to disable it. This is the default.
+// See examples/sortable-table.
+func (w *MasterWindow) SetUserFile(path string) {
+	w.io.SetIniFilename(path)
 }

--- a/examples/sortable-table/main.go
+++ b/examples/sortable-table/main.go
@@ -22,7 +22,7 @@ func rebuildColumns() {
 
 func loop() {
 	giu.SingleWindow().Layout(
-		giu.Table().Flags(giu.TableFlagsSortable).Columns(
+		giu.Table().Flags(giu.TableFlagsSortable|giu.TableFlagsResizable).Columns(
 			giu.TableColumn("Col 1").Sort(func(s giu.SortDirection) {
 				fmt.Println("sorting col 1", s)
 				switch s {
@@ -41,6 +41,7 @@ func loop() {
 
 func main() {
 	wnd := giu.NewMasterWindow("Table sorting", 640, 480, 0)
+	wnd.SetUserFile("giu.ini")
 
 	rebuildColumns()
 


### PR DESCRIPTION
See #987.

On a `MasterWindow`, you can call `SetUserFile` to specify the path to a user .ini file (for saving subwindow locations, table column widths, etc).

`examples/sortable-table` has an example.