### PR TITLE
Don't scale the font size on macOS

### DIFF
--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -379,10 +379,10 @@ func (a *FontAtlas) rebuildFontAtlas() {
 
 func scaleFont(fontInfo FontInfo) (newSize float32) {
 	if runtime.GOOS == darwin {
-		// don't increase the font size; otherwise font gets mistakenly extra 2x on HiDPI displays
-		return fontInfo.size
+		return fontInfo.size // don't increase the font size; otherwise font gets mistakenly extra 2x on HiDPI displays
 	}
 
 	xScale, _ := Context.backend.ContentScale()
+
 	return fontInfo.size * xScale
 }


### PR DESCRIPTION
Since v0.14.x, the UI font size became twice as big on macOS with Retina display.
Looks like giu/cimgui-go/imgui handle the display scale fine without any extra work on Mac.

This PR skips the font size increase on macOS.

Not sure if this change can break anything for other people. I'd definitely wouldn't merge this without someone else confirming whether they also have this issue.

Would love to help testing this further if needed.

<details><summary>Screenshots / comparison</summary>
<p>

**Display mode:** HiDPI (Retina)
**Native resolution:** 3024x1964
**"Usable" resolution:** 1800x1169
**Top:** v0.14.1 / **Bottom:** v0.13.0
[<img width="218" height="222" alt="image" src="https://github.com/user-attachments/assets/57ba1d71-6fe6-46d9-9a28-45ec84a8f180" />](https://github.com/user-attachments/assets/57ba1d71-6fe6-46d9-9a28-45ec84a8f180)

**Display mode:** HiDPI (Retina)
**Native resolution:** 3024x1964
**"Usable" resolution:** 1800x1169
**Left:** v0.13.0 / **Right:** v0.14.1
[<img width="423" height="242" alt="image" src="https://github.com/user-attachments/assets/6cedcc64-c188-4ec8-a249-7ca6509b8bc1" />](https://github.com/user-attachments/assets/6cedcc64-c188-4ec8-a249-7ca6509b8bc1)

**Display mode:** forced non-HiDPI
**Native resolution:** 1920x1200
**"Usable" resolution:** 1920x1200
**Left:** v0.13.0 / **Right:** v0.14.1
<img width="423" height="242" alt="image" src="https://github.com/user-attachments/assets/5fb6ae88-8d96-4e75-8ee3-9aa535197998" />

</p>
</details> 
