### PR TITLE
Introduce Context.WithLock

### DIFF
--- a/Context.go
+++ b/Context.go
@@ -214,6 +214,12 @@ func (c *GIUContext) GetState(id ID) any {
 	return nil
 }
 
+func (c *GIUContext) WithLock(fn func()) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	fn()
+}
+
 func (c *GIUContext) load(id any) (*state, bool) {
 	if v, ok := c.state.Load(id); ok {
 		if s, ok := v.(*state); ok {

--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -205,23 +205,25 @@ func (w *MasterWindow) beforeRender() {
 
 	Context.FontAtlas.rebuildFontAtlas()
 
-	// process texture load requests
-	if Context.textureLoadingQueue != nil && Context.textureLoadingQueue.Length() > 0 {
-		for Context.textureLoadingQueue.Length() > 0 {
-			request, ok := Context.textureLoadingQueue.Remove().(textureLoadRequest)
-			Assert(ok, "MasterWindow", "Run", "processing texture requests: wrong type of texture request")
-			NewTextureFromRgba(request.img, request.cb)
+	Context.WithLock(func() {
+		// process texture load requests
+		if Context.textureLoadingQueue != nil && Context.textureLoadingQueue.Length() > 0 {
+			for Context.textureLoadingQueue.Length() > 0 {
+				request, ok := Context.textureLoadingQueue.Remove().(textureLoadRequest)
+				Assert(ok, "MasterWindow", "Run", "processing texture requests: wrong type of texture request")
+				NewTextureFromRgba(request.img, request.cb)
+			}
 		}
-	}
 
-	// process texture free requests
-	if Context.textureFreeingQueue != nil && Context.textureFreeingQueue.Length() > 0 {
-		for Context.textureFreeingQueue.Length() > 0 {
-			request, ok := Context.textureFreeingQueue.Remove().(textureFreeRequest)
-			Assert(ok, "MasterWindow", "Run", "processing texture requests: wrong type of texture request")
-			request.tex.tex.Release()
+		// process texture free requests
+		if Context.textureFreeingQueue != nil && Context.textureFreeingQueue.Length() > 0 {
+			for Context.textureFreeingQueue.Length() > 0 {
+				request, ok := Context.textureFreeingQueue.Remove().(textureFreeRequest)
+				Assert(ok, "MasterWindow", "Run", "processing texture requests: wrong type of texture request")
+				request.tex.tex.Release()
+			}
 		}
-	}
+	})
 }
 
 func (w *MasterWindow) afterRender() {

--- a/Texture.go
+++ b/Texture.go
@@ -28,7 +28,9 @@ type textureFreeRequest struct {
 // NOTE: remember to call it after NewMasterWindow!
 func EnqueueNewTextureFromRgba(rgba image.Image, loadCb func(t *Texture)) {
 	Assert((Context.textureLoadingQueue != nil), "", "EnqueueNewTextureFromRgba", "you need to call EnqueueNewTextureFromRgba after giu.NewMasterWindow call!")
-	Context.textureLoadingQueue.Add(textureLoadRequest{rgba, loadCb})
+	Context.WithLock(func() {
+		Context.textureLoadingQueue.Add(textureLoadRequest{rgba, loadCb})
+	})
 }
 
 // NewTextureFromRgba creates a new texture from image.Image and, when it is done, calls loadCallback(loadedTexture).
@@ -39,7 +41,9 @@ func NewTextureFromRgba(rgba image.Image, loadCallback func(*Texture)) {
 	}
 
 	runtime.SetFinalizer(giuTex, func(tex *Texture) {
-		Context.textureFreeingQueue.Add(textureFreeRequest{tex})
+		Context.WithLock(func() {
+			Context.textureFreeingQueue.Add(textureFreeRequest{tex})
+		})
 	})
 
 	loadCallback(giuTex)


### PR DESCRIPTION
 Summary

  - Introduces Context.WithLock() method to provide thread-safe access to context operations
  - Wraps texture loading and freeing queue operations with proper mutex protection
  - Prevents race conditions when multiple threads enqueue texture operations simultaneously

The texture loading and freeing queues were not thread-safe when accessed from multiple goroutines. This could lead to queue corruption and unpredictable behavior when textures were being loaded or freed concurrently.

Thus, I added a WithLock() method to the GIUContext that safely executes functions while holding the context mutex. This ensures that:
  1. Texture load requests enqueued via EnqueueNewTextureFromRgba() are thread-safe
  2. Texture free requests triggered by finalizers are thread-safe
  3. Queue processing in the render loop is protected from concurrent modifications

Files modified:
  - Context.go: Added WithLock() method for safe mutex-protected operations
  - MasterWindow.go: Wrapped texture queue processing in WithLock() during render
  - Texture.go: Protected queue operations in both EnqueueNewTextureFromRgba() and the texture finalizer