### PR TITLE
workflows: refer to go.mod in setup-go call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version-file: 'go.mod'
         id: go
 
       - name: Cache Go modules


### PR DESCRIPTION
setup-go used hardcoded go version which is not good especially when go.mod requires newer go version. Now setup-go checks go.mod for the right version.