### PR TITLE
BREAKING Font Atlas size handling rework

### DIFF
--- a/CSS.go
+++ b/CSS.go
@@ -92,7 +92,7 @@ func (c *CSSStylesheet) GetTag(tag string) (result *StyleSetter) {
 		return Style()
 	}
 
-	return
+	return result
 }
 
 // Parse parses CSS stylesheet and stores the rules in the receiver.

--- a/Context_test.go
+++ b/Context_test.go
@@ -3,6 +3,7 @@ package giu
 import (
 	"testing"
 
+	"github.com/AllenDang/cimgui-go/imgui"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,6 +20,7 @@ func (t *teststate2) Dispose() {
 }
 
 func Test_SetGetState(t *testing.T) {
+	imgui.CreateContext()
 	tests := []struct {
 		id   ID
 		data *teststate

--- a/Context_test.go
+++ b/Context_test.go
@@ -21,6 +21,7 @@ func (t *teststate2) Dispose() {
 
 func Test_SetGetState(t *testing.T) {
 	imgui.CreateContext()
+
 	tests := []struct {
 		id   ID
 		data *teststate

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -33,21 +33,10 @@ func (f *FontInfo) String() string {
 	return fmt.Sprintf("%s:%.2f", f.fontName, f.size)
 }
 
-// SetSize sets the font size.
+// SetSize sets the font size for the current font.
 func (f *FontInfo) SetSize(size float32) *FontInfo {
-	result := *f
-	result.size = size
-
-	for _, i := range Context.FontAtlas.extraFonts {
-		if i.String() == result.String() {
-			return &result
-		}
-	}
-
-	Context.FontAtlas.extraFonts = append(Context.FontAtlas.extraFonts, result)
-	Context.FontAtlas.shouldRebuildFontAtlas = true
-
-	return &result
+	f.size = size
+	return f
 }
 
 // FontAtlas is a mechanism to automatically manage fonts in giu.

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -114,7 +114,6 @@ func (a *FontAtlas) AutoRegisterStrings(b bool) {
 
 // SetDefaultFontSize sets the default font size.
 func (a *FontAtlas) SetDefaultFontSize(size float32) {
-	// imgui.CurrentContext().SetFontSizeBase(size)
 	imgui.CurrentStyle().SetFontSizeBase(size)
 }
 

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -17,7 +17,8 @@ const (
 	preRegisterString = " \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 	darwin            = "darwin"
 	windows           = "windows"
-	defaultFontSize   = 14
+	// DefaultFontSize is the default font size used in giu.
+	DefaultFontSize = 14
 )
 
 // FontInfo represents a giu implementation of imgui font.
@@ -53,7 +54,7 @@ func newFontAtlas() *FontAtlas {
 		autoRegisterStrings: true,
 	}
 
-	result.SetDefaultFontSize(defaultFontSize)
+	result.SetDefaultFontSize(DefaultFontSize)
 
 	// Pre register numbers
 	result.RegisterString(preRegisterString)

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -30,7 +30,7 @@ type FontInfo struct {
 
 // String returns a string representation of the FontInfo. It is intended to be unique for each FontInfo.
 func (f *FontInfo) String() string {
-	return fmt.Sprintf("%s", f.fontName)
+	return f.fontName
 }
 
 // FontAtlas is a mechanism to automatically manage fonts in giu.

--- a/MasterWindow.go
+++ b/MasterWindow.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"image"
 	"image/color"
-	"runtime"
 
 	"github.com/AllenDang/cimgui-go/backend"
 	"github.com/AllenDang/cimgui-go/backend/glfwbackend"
@@ -117,11 +116,7 @@ func NewMasterWindow(title string, width, height int, flags MasterWindowFlags) *
 
 	mw.SetBgColor(colornames.Black)
 
-	// Scale DPI in windows
-	if runtime.GOOS == "windows" {
-		xScale, _ := Context.backend.ContentScale()
-		imgui.CurrentStyle().ScaleAllSizes(xScale)
-	}
+	mw.SetScale(0) // set content scale
 
 	return mw
 }
@@ -437,4 +432,17 @@ func (w *MasterWindow) SetAdditionalInputHandlerCallback(cb InputHandlerHandleCa
 // See examples/sortable-table.
 func (w *MasterWindow) SetUserFile(path string) {
 	w.io.SetIniFilename(path)
+}
+
+// SetScale is executed internally by NewMasterWindow with the default content scale factor.
+// You can call it if you relly want.
+// If 0 passed, ContentScale will be re-applied.
+func (w *MasterWindow) SetScale(scale float32) {
+	if scale == 0 {
+		scale, _ = Context.backend.ContentScale()
+	}
+
+	s := imgui.CurrentStyle()
+	s.ScaleAllSizes(scale)
+	s.SetFontScaleDpi(scale)
 }

--- a/Style.go
+++ b/Style.go
@@ -46,7 +46,7 @@ func PushFont(font *FontInfo) bool {
 	}
 
 	if f, ok := Context.FontAtlas.extraFontMap[font.String()]; ok {
-		imgui.PushFont(f, 0)
+		imgui.PushFont(f, font.Size)
 		return true
 	}
 

--- a/Style.go
+++ b/Style.go
@@ -53,12 +53,16 @@ func PushFont(font *FontInfo) bool {
 	return false
 }
 
+// PushFontSize sets font size for the current font.
+// NOTE: PopFont has to be called
+// NOTE: you can use (*StyleSetter).SetFontSize instead.
 func PushFontSize(size float32) bool {
 	if size <= 0 {
 		return false
 	}
 
 	imgui.PushFont(imgui.CurrentFont(), size)
+
 	return true
 }
 

--- a/Style.go
+++ b/Style.go
@@ -46,7 +46,7 @@ func PushFont(font *FontInfo) bool {
 	}
 
 	if f, ok := Context.FontAtlas.extraFontMap[font.String()]; ok {
-		imgui.PushFont(f, font.Size)
+		imgui.PushFont(f, 0)
 		return true
 	}
 

--- a/Style.go
+++ b/Style.go
@@ -53,6 +53,15 @@ func PushFont(font *FontInfo) bool {
 	return false
 }
 
+func PushFontSize(size float32) bool {
+	if size <= 0 {
+		return false
+	}
+
+	imgui.PushFont(imgui.CurrentFont(), size)
+	return true
+}
+
 // PopFont pops the font (should be called after PushFont).
 func PopFont() {
 	imgui.PopFont()

--- a/StyleSetter.go
+++ b/StyleSetter.go
@@ -110,7 +110,7 @@ func (ss *StyleSetter) GetStyle(varID StyleVarID) (width, height float32) {
 		width, height = vec.X, vec.Y
 	}
 
-	return
+	return width, height
 }
 
 // SetStyleFloat sets styleVarID to float value.
@@ -155,7 +155,7 @@ func (ss *StyleSetter) GetPlotStyle(varID StylePlotVarID) (width, height float32
 		width, height = vec.X, vec.Y
 	}
 
-	return
+	return width, height
 }
 
 // SetPlotStyleFloat sets StylePlotVarID to float value.

--- a/StyleSetter.go
+++ b/StyleSetter.go
@@ -17,6 +17,7 @@ type StyleSetter struct {
 	plotColors map[StylePlotColorID]color.Color
 	plotStyles map[StylePlotVarID]any
 	font       *FontInfo
+	fontSize   float32
 	disabled   bool
 
 	layout Layout
@@ -185,14 +186,8 @@ func (ss *StyleSetter) SetFont(font *FontInfo) *StyleSetter {
 // NOTE: Be aware, that StyleSetter needs to add a new font to font atlas for
 // each font's size.
 func (ss *StyleSetter) SetFontSize(size float32) *StyleSetter {
-	var font FontInfo
-	if ss.font != nil {
-		font = *ss.font
-	} else {
-		font = Context.FontAtlas.defaultFonts[0]
-	}
-
-	ss.font = font.SetSize(size)
+	Assert(size > 0, "StyleSetter", "SetFontSize", "font size must be positive")
+	ss.fontSize = size
 
 	return ss
 }
@@ -327,6 +322,10 @@ func (ss *StyleSetter) Push() {
 		ss.isFontPushed = PushFont(ss.font)
 	}
 
+	if ss.fontSize != 0 {
+		PushFontSize(ss.fontSize)
+	}
+
 	if ss.disabled {
 		imgui.BeginDisabled()
 	}
@@ -334,6 +333,10 @@ func (ss *StyleSetter) Push() {
 
 // Pop allows to manually pop the whole StyleSetter (use after Push!)
 func (ss *StyleSetter) Pop() {
+	if ss.fontSize != 0 {
+		imgui.PopFont()
+	}
+
 	if ss.isFontPushed {
 		imgui.PopFont()
 	}

--- a/examples/markdown/markdown.go
+++ b/examples/markdown/markdown.go
@@ -64,8 +64,8 @@ func loop() {
 				}),
 			},
 			giu.Markdown(markdown).
-				Header(0, (giu.Context.FontAtlas.GetDefaultFonts())[0].SetSize(28), true).
-				Header(1, (giu.Context.FontAtlas.GetDefaultFonts())[0].SetSize(26), false).
+				Header(0, nil, true).
+				Header(1, nil, false).
 				Header(2, nil, true),
 		),
 	)

--- a/examples/multiplefonts/multiplefonts.go
+++ b/examples/multiplefonts/multiplefonts.go
@@ -6,19 +6,19 @@ import (
 )
 
 var (
-	bigFont *g.FontInfo
+	anotherFont *g.FontInfo
 
 	content = "Hello world from giu!\n你好啊世界！"
 )
 
 func loop() {
 	g.SingleWindow().Layout(
-		g.Label("Title line").Font(bigFont),
+		g.Label("Title line").Font(anotherFont),
 		g.Label("Content line"),
 
 		g.Label("Change font for other widgets"),
 
-		g.Style().SetFont(bigFont).To(
+		g.Style().SetFont(anotherFont).SetFontSize(28).To(
 			g.Button("Button with big font"),
 		),
 
@@ -36,10 +36,10 @@ func main() {
 	wnd := g.NewMasterWindow("Multiple fonts", 600, 400, g.MasterWindowFlagsNotResizable)
 
 	// Change the default font
-	g.Context.FontAtlas.SetDefaultFont("Arial.ttf", 12)
+	g.Context.FontAtlas.SetDefaultFont("Arial.ttf")
 
 	// Add a new font and manually set it when needed
-	bigFont = g.Context.FontAtlas.AddFont("Menlo.ttc", 24)
+	anotherFont = g.Context.FontAtlas.AddFont("Menlo.ttc")
 
 	wnd.Run(loop)
 }


### PR DESCRIPTION
after #1028 Font atlas should be completely reworked (or maybe even removed (?)
This is WIP Pull Request.

## Breaking Changes
- Remove eintire `(*FontInfo).size` mechanism (ncluding `SetSize`) method
- Remove `size` parameter from all the SetDefaultFont*, AddFont* methods