### PR TITLE
Font atlas: remove glyph ranges

### DIFF
--- a/Canvas.go
+++ b/Canvas.go
@@ -81,7 +81,7 @@ func (c *Canvas) AddRectFilled(pMin, pMax image.Point, col color.Color, rounding
 
 // AddText draws text.
 func (c *Canvas) AddText(pos image.Point, col color.Color, text string) {
-	c.DrawList.AddTextVec2(ToVec2(pos), ColorToUint(col), Context.FontAtlas.RegisterString(text))
+	c.DrawList.AddTextVec2(ToVec2(pos), ColorToUint(col), Context.PrepareString(text))
 }
 
 // AddBezierCubic draws bezier cubic.

--- a/ClickableWidgets.go
+++ b/ClickableWidgets.go
@@ -188,7 +188,7 @@ func (b *InvisibleButtonWidget) ID(id ID) *InvisibleButtonWidget {
 
 // Build implements Widget interface.
 func (b *InvisibleButtonWidget) Build() {
-	if imgui.InvisibleButton(Context.FontAtlas.RegisterString(b.id.String()), imgui.Vec2{X: b.width, Y: b.height}) && b.onClick != nil {
+	if imgui.InvisibleButton(b.id.String(), imgui.Vec2{X: b.width, Y: b.height}) && b.onClick != nil {
 		b.onClick()
 	}
 }
@@ -619,7 +619,7 @@ func (l *LinkWidget) OnClick(onClick func()) *LinkWidget {
 
 // Build implements Widget interface.
 func (l *LinkWidget) Build() {
-	if imgui.TextLink(Context.FontAtlas.RegisterString(l.text.String())) && l.onClick != nil {
+	if imgui.TextLink(Context.PrepareString(l.text.String())) && l.onClick != nil {
 		l.onClick()
 	}
 }

--- a/CodeEditor.go
+++ b/CodeEditor.go
@@ -210,9 +210,6 @@ func (ce *CodeEditorWidget) Delete() {
 func (ce *CodeEditorWidget) Build() {
 	s := ce.getState()
 
-	// register text in font atlas
-	Context.FontAtlas.RegisterString(s.editor.Text())
-
 	// build editor
 	s.editor.RenderV(string(ce.title), false, imgui.Vec2{X: ce.width, Y: ce.height}, ce.border)
 }

--- a/Context.go
+++ b/Context.go
@@ -111,13 +111,28 @@ func (c *GIUContext) SetDirty() {
 }
 
 // PrepareString prepares string to be displayed by imgui.
-// It does the following:
-// - adds a string to the FontAtlas
+// It does the following (exactly one at the moment):
 // - translates the string with the Translator set in the context
+//
+//	  NOTE: content of the following items is NOT translated:
+//	* CodeEditor
+//	* Popup Labels (it is important to know their EXACT value)
+//	* everything that is a pointer
+//
 // Not all widgets will use this. Text with user-defined input (e.g. InputText will still use FontAtlas.RegisterString).
 func (c *GIUContext) PrepareString(str string) string {
-	str = c.Translator.Translate(str)
-	return c.FontAtlas.RegisterString(str)
+	return c.Translator.Translate(str)
+}
+
+// PrepareStringSlice is a version of PrepareString that works on slices.
+func (c *GIUContext) PrepareStringSlice(strs []string) []string {
+	result := make([]string, len(strs))
+
+	for i, s := range strs {
+		result[i] = c.PrepareString(s)
+	}
+
+	return result
 }
 
 // SetCSSStylesheet sets the "main" stylesheet for the context.

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -185,28 +185,6 @@ func (a *FontAtlas) registerDefaultFonts(fontInfos []FontInfo) {
 	}
 }
 
-// It could be disabled by AutoRegisterStrings.
-func (a *FontAtlas) RegisterString(str string) string {
-	return str
-}
-
-// PreRegisterString register string to font atlas builder.
-// NOTE only register strings that will be displayed on the UI.
-func (a *FontAtlas) PreRegisterString(str string) string {
-	return str
-}
-
-// RegisterStringPointer registers string pointer to font atlas builder.
-// Note only register strings that will be displayed on the UI.
-func (a *FontAtlas) RegisterStringPointer(str *string) *string {
-	return str
-}
-
-// RegisterStringSlice calls RegisterString for each slice element.
-func (a *FontAtlas) RegisterStringSlice(str []string) []string {
-	return str
-}
-
 // Rebuild font atlas when necessary.
 // The whole magic happens here.
 func (a *FontAtlas) rebuildFontAtlas() {

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"runtime"
-	"strings"
 	"sync"
 	"unsafe"
 
@@ -14,9 +13,8 @@ import (
 )
 
 const (
-	preRegisterString = " \"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-	darwin            = "darwin"
-	windows           = "windows"
+	darwin  = "darwin"
+	windows = "windows"
 	// DefaultFontSize is the default font size used in giu.
 	DefaultFontSize = 14
 )
@@ -55,9 +53,6 @@ func newFontAtlas() *FontAtlas {
 	}
 
 	result.SetDefaultFontSize(DefaultFontSize)
-
-	// Pre register numbers
-	result.RegisterString(preRegisterString)
 
 	// Pre-register fonts
 	switch runtime.GOOS {
@@ -249,30 +244,6 @@ func (a *FontAtlas) rebuildFontAtlas() {
 
 	fonts := Context.IO().Fonts()
 	fonts.Clear()
-
-	var sb strings.Builder
-
-	a.stringMap.Range(func(k, _ any) bool {
-		a.stringMap.Store(k, true)
-
-		if ks, ok := k.(rune); ok {
-			sb.WriteRune(ks)
-		}
-
-		return true
-	})
-
-	ranges := imgui.NewGlyphRange()
-	builder := imgui.NewFontGlyphRangesBuilder()
-
-	// Because we pre-registered numbers, so default string map's length should greater then 11.
-	if sb.Len() > len(preRegisterString) {
-		builder.AddText(sb.String())
-	} else {
-		builder.AddRanges(fonts.GlyphRangesDefault())
-	}
-
-	builder.BuildRanges(ranges)
 
 	if len(a.defaultFonts) > 0 {
 		fontConfig := imgui.NewFontConfig()

--- a/FontAtlasProsessor.go
+++ b/FontAtlasProsessor.go
@@ -290,7 +290,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 					fontInfo.fontPath,
 					0,
 					fontConfig,
-					ranges.Data(),
+					nil,
 				)
 			} else {
 				fontConfig.SetFontDataOwnedByAtlas(false)
@@ -299,7 +299,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 					int32(len(fontInfo.fontByte)),
 					0,
 					fontConfig,
-					ranges.Data(),
+					nil,
 				)
 			}
 		}
@@ -321,7 +321,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 				fontInfo.fontPath,
 				0,
 				imgui.NewFontConfig(),
-				ranges.Data(),
+				nil,
 			)
 		} else {
 			fontConfig := imgui.NewFontConfig()
@@ -331,7 +331,7 @@ func (a *FontAtlas) rebuildFontAtlas() {
 				int32(len(fontInfo.fontByte)),
 				0,
 				fontConfig,
-				ranges.Data(),
+				nil,
 			)
 		}
 

--- a/Markdown.go
+++ b/Markdown.go
@@ -129,7 +129,7 @@ func (m *MarkdownWidget) Header(level int, font *FontInfo, fontSize float32, sep
 func (m *MarkdownWidget) Build() {
 	state := m.getState()
 	immarkdown.Markdown(
-		Context.FontAtlas.RegisterString(m.md),
+		Context.PrepareString(m.md),
 		uint64(len(m.md)),
 		state.cfg,
 	)

--- a/Plot.go
+++ b/Plot.go
@@ -248,7 +248,7 @@ func (p *PlotCanvasWidget) Build() {
 	}
 
 	if implot.BeginPlotV(
-		Context.FontAtlas.RegisterString(p.title),
+		Context.PrepareString(p.title),
 		ToVec2(image.Pt(p.width, p.height)),
 		implot.Flags(p.flags),
 	) {
@@ -310,20 +310,20 @@ func (p *PlotCanvasWidget) Build() {
 
 		implot.SetupAxisV(
 			implot.AxisX1,
-			Context.FontAtlas.RegisterString(p.xLabel),
+			Context.PrepareString(p.xLabel),
 			implot.AxisFlags(p.xFlags),
 		)
 
 		implot.SetupAxisV(
 			implot.AxisY1,
-			Context.FontAtlas.RegisterString(p.yLabel),
+			Context.PrepareString(p.yLabel),
 			implot.AxisFlags(p.yFlags),
 		)
 
 		if p.y2Label != "" {
 			implot.SetupAxisV(
 				implot.AxisY2,
-				Context.FontAtlas.RegisterString(p.y2Label),
+				Context.PrepareString(p.y2Label),
 				implot.AxisFlags(p.y2Flags),
 			)
 		}
@@ -331,7 +331,7 @@ func (p *PlotCanvasWidget) Build() {
 		if p.y3Label != "" {
 			implot.SetupAxisV(
 				implot.AxisY3,
-				Context.FontAtlas.RegisterString(p.y3Label),
+				Context.PrepareString(p.y3Label),
 				implot.AxisFlags(p.y3Flags),
 			)
 		}
@@ -444,7 +444,7 @@ func (p *BarHPlot) Offset(offset int) *BarHPlot {
 // Plot implements plot interface.
 func (p *BarHPlot) Plot() {
 	implot.PlotBarsdoublePtrIntV(
-		Context.FontAtlas.RegisterString(p.title),
+		Context.PrepareString(p.title),
 		utils.SliceToPtr(p.data),
 		int32(len(p.data)),
 		p.height,
@@ -506,7 +506,7 @@ func (p *LinePlot) Plot() {
 	)
 
 	implot.PlotLinedoublePtrIntV(
-		Context.FontAtlas.RegisterString(p.title),
+		Context.PrepareString(p.title),
 		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
 		p.xScale,
@@ -551,7 +551,7 @@ func (p *LineXYPlot) Offset(offset int) *LineXYPlot {
 func (p *LineXYPlot) Plot() {
 	implot.SetAxis(implot.AxisEnum(p.yAxis))
 	implot.PlotLinedoublePtrdoublePtrV(
-		Context.FontAtlas.RegisterString(p.title),
+		Context.PrepareString(p.title),
 		utils.SliceToPtr(p.xs),
 		utils.SliceToPtr(p.ys),
 		int32(len(p.xs)),
@@ -612,7 +612,7 @@ func (p *PieChartPlot) Plot() {
 	}
 
 	implot.PlotPieChartdoublePtrStrV(
-		Context.FontAtlas.RegisterStringSlice(p.labels),
+		Context.PrepareStringSlice(p.labels),
 		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
 		p.x,
@@ -664,7 +664,7 @@ func (p *ScatterPlot) Offset(offset int) *ScatterPlot {
 // Plot implements Plot interface.
 func (p *ScatterPlot) Plot() {
 	implot.PlotScatterdoublePtrIntV(
-		Context.FontAtlas.RegisterString(p.label),
+		Context.PrepareString(p.label),
 		utils.SliceToPtr(p.values),
 		int32(len(p.values)),
 		p.xscale,
@@ -701,7 +701,7 @@ func (p *ScatterXYPlot) Offset(offset int) *ScatterXYPlot {
 // Plot implements Plot interface.
 func (p *ScatterXYPlot) Plot() {
 	implot.PlotScatterdoublePtrdoublePtrV(
-		Context.FontAtlas.RegisterString(p.label),
+		Context.PrepareString(p.label),
 		utils.SliceToPtr(p.xs),
 		utils.SliceToPtr(p.ys),
 		int32(len(p.xs)),

--- a/Popups.go
+++ b/Popups.go
@@ -56,7 +56,7 @@ type PopupWidget struct {
 // Popup creates new popup widget.
 func Popup(name string) *PopupWidget {
 	return &PopupWidget{
-		name:   Context.FontAtlas.RegisterString(name),
+		name:   name,
 		flags:  0,
 		layout: nil,
 	}
@@ -98,7 +98,7 @@ type PopupModalWidget struct {
 // PopupModal creates new popup modal widget.
 func PopupModal(name string) *PopupModalWidget {
 	return &PopupModalWidget{
-		name:   Context.FontAtlas.RegisterString(name),
+		name:   name,
 		open:   nil,
 		flags:  WindowFlagsNoResize,
 		layout: nil,

--- a/ProgressIndicator.go
+++ b/ProgressIndicator.go
@@ -117,7 +117,7 @@ func (p *ProgressIndicatorWidget) Build() {
 
 				// Draw text
 				if p.label != "" {
-					labelWidth, _ := CalcTextSize(Context.FontAtlas.RegisterString(p.label))
+					labelWidth, _ := CalcTextSize(Context.PrepareString(p.label))
 					labelPos := centerPt.Add(image.Pt(-1*int(labelWidth/2), int(p.radius+p.radius/5+8)))
 					canvas.AddText(labelPos, rgba, p.label)
 				}

--- a/SliderWidgets.go
+++ b/SliderWidgets.go
@@ -78,7 +78,7 @@ func (s *SliderIntWidget) Build() {
 		defer PopItemWidth()
 	}
 
-	if imgui.SliderIntV(Context.FontAtlas.RegisterString(s.label.String()), s.value, s.minValue, s.maxValue, s.format, 0) && s.onChange != nil {
+	if imgui.SliderIntV(Context.PrepareString(s.label.String()), s.value, s.minValue, s.maxValue, s.format, 0) && s.onChange != nil {
 		s.onChange()
 	}
 }
@@ -156,7 +156,7 @@ func (vs *VSliderIntWidget) ID(id ID) *VSliderIntWidget {
 // Build implements Widget interface.
 func (vs *VSliderIntWidget) Build() {
 	if imgui.VSliderIntV(
-		Context.FontAtlas.RegisterString(vs.label.String()),
+		Context.PrepareString(vs.label.String()),
 		imgui.Vec2{X: vs.width, Y: vs.height},
 		vs.value,
 		vs.minValue,
@@ -217,7 +217,7 @@ func (sf *SliderFloatWidget) Size(width float32) *SliderFloatWidget {
 
 // Label sets slider's label (id).
 func (sf *SliderFloatWidget) Label(label string) *SliderFloatWidget {
-	sf.label = GenAutoID(Context.FontAtlas.RegisterString(label))
+	sf.label = GenAutoID(Context.PrepareString(label))
 	return sf
 }
 
@@ -417,7 +417,7 @@ func (d *DragFloatWidget) OnChange(onChange func()) *DragFloatWidget {
 
 // Build implements Widget interface.
 func (d *DragFloatWidget) Build() {
-	if imgui.DragFloatV(Context.FontAtlas.RegisterString(d.label.String()), d.value, d.speed, d.minValue, d.maxValue, d.format, imgui.SliderFlags(d.flags)) && d.onChange != nil {
+	if imgui.DragFloatV(Context.PrepareString(d.label.String()), d.value, d.speed, d.minValue, d.maxValue, d.format, imgui.SliderFlags(d.flags)) && d.onChange != nil {
 		d.onChange()
 	}
 }

--- a/TableWidgets.go
+++ b/TableWidgets.go
@@ -86,7 +86,7 @@ type TableColumnWidget struct {
 // TableColumn creates a new TableColumnWidget.
 func TableColumn(label string) *TableColumnWidget {
 	return &TableColumnWidget{
-		label:              Context.FontAtlas.RegisterString(label),
+		label:              Context.PrepareString(label),
 		flags:              0,
 		innerWidthOrWeight: 0,
 		userID:             0,
@@ -328,10 +328,10 @@ func (ttr *TreeTableRowWidget) BuildTreeTableRow() {
 
 	open := false
 	if len(ttr.children) > 0 {
-		open = imgui.TreeNodeExStrV(Context.FontAtlas.RegisterString(ttr.label.String()), imgui.TreeNodeFlags(ttr.flags))
+		open = imgui.TreeNodeExStrV(Context.PrepareString(ttr.label.String()), imgui.TreeNodeFlags(ttr.flags))
 	} else {
 		ttr.flags |= TreeNodeFlagsLeaf | TreeNodeFlagsNoTreePushOnOpen
-		imgui.TreeNodeExStrV(Context.FontAtlas.RegisterString(ttr.label.String()), imgui.TreeNodeFlags(ttr.flags))
+		imgui.TreeNodeExStrV(Context.PrepareString(ttr.label.String()), imgui.TreeNodeFlags(ttr.flags))
 	}
 
 	for _, w := range ttr.layout {

--- a/TextWidgets.go
+++ b/TextWidgets.go
@@ -87,8 +87,8 @@ func (i *InputTextMultilineWidget) AutoScrollToBottom(b bool) *InputTextMultilin
 // Build implements Widget interface.
 func (i *InputTextMultilineWidget) Build() {
 	if imgui.InputTextMultiline(
-		Context.FontAtlas.RegisterString(i.label.String()),
-		Context.FontAtlas.RegisterStringPointer(i.text),
+		Context.PrepareString(i.label.String()),
+		i.text,
 		imgui.Vec2{
 			X: i.width,
 			Y: i.height,
@@ -188,7 +188,7 @@ func InputText(value *string) *InputTextWidget {
 
 // Label adds label (alternatively you can use it to set widget's id).
 func (i *InputTextWidget) Label(label string) *InputTextWidget {
-	i.label = GenAutoID(Context.FontAtlas.RegisterString(label))
+	i.label = GenAutoID(Context.PrepareString(label))
 	return i
 }
 
@@ -212,7 +212,7 @@ func (i *InputTextWidget) AutoComplete(candidates []string) *InputTextWidget {
 
 // Hint sets hint text.
 func (i *InputTextWidget) Hint(hint string) *InputTextWidget {
-	i.hint = Context.FontAtlas.RegisterString(hint)
+	i.hint = Context.PrepareString(hint)
 	return i
 }
 
@@ -255,7 +255,7 @@ func (i *InputTextWidget) Build() {
 		defer PopItemWidth()
 	}
 
-	isChanged := imgui.InputTextWithHint(i.label.String(), i.hint, Context.FontAtlas.RegisterStringPointer(i.value), imgui.InputTextFlags(i.flags), i.cb)
+	isChanged := imgui.InputTextWithHint(i.label.String(), i.hint, i.value, imgui.InputTextFlags(i.flags), i.cb)
 
 	if isChanged && i.onChange != nil {
 		i.onChange()
@@ -351,7 +351,7 @@ func InputInt(value *int32) *InputIntWidget {
 
 // Label sets label (id).
 func (i *InputIntWidget) Label(label string) *InputIntWidget {
-	i.label = GenAutoID(Context.FontAtlas.RegisterString(label))
+	i.label = GenAutoID(Context.PrepareString(label))
 	return i
 }
 
@@ -443,7 +443,7 @@ func InputFloat(value *float32) *InputFloatWidget {
 
 // Label sets label of input field.
 func (i *InputFloatWidget) Label(label string) *InputFloatWidget {
-	i.label = GenAutoID(Context.FontAtlas.RegisterString(label))
+	i.label = GenAutoID(Context.PrepareString(label))
 	return i
 }
 

--- a/Widgets.go
+++ b/Widgets.go
@@ -141,7 +141,7 @@ type ComboCustomWidget struct {
 func ComboCustom(label, previewValue string) *ComboCustomWidget {
 	return &ComboCustomWidget{
 		label:        GenAutoID(label),
-		previewValue: Context.FontAtlas.RegisterString(previewValue),
+		previewValue: Context.PrepareString(previewValue),
 		width:        0,
 		flags:        0,
 		layout:       nil,
@@ -209,8 +209,8 @@ type ComboWidget struct {
 func Combo(label, previewValue string, items []string, selected *int32) *ComboWidget {
 	return &ComboWidget{
 		label:        GenAutoID(label),
-		previewValue: Context.FontAtlas.RegisterString(previewValue),
-		items:        Context.FontAtlas.RegisterStringSlice(items),
+		previewValue: Context.PrepareString(previewValue),
+		items:        Context.PrepareStringSlice(items),
 		selected:     selected,
 		flags:        0,
 		width:        0,
@@ -550,7 +550,7 @@ func (p *ProgressBarWidget) Size(width, height float32) *ProgressBarWidget {
 
 // Overlay sets custom overlay displayed on the bar.
 func (p *ProgressBarWidget) Overlay(overlay string) *ProgressBarWidget {
-	p.overlay = Context.FontAtlas.RegisterString(overlay)
+	p.overlay = Context.PrepareString(overlay)
 	return p
 }
 
@@ -739,7 +739,7 @@ type TooltipWidget struct {
 // NOTE: you can set the empty label and use Layout() method.
 func Tooltip(tip string) *TooltipWidget {
 	return &TooltipWidget{
-		tip:    Context.FontAtlas.RegisterString(tip),
+		tip:    Context.PrepareString(tip),
 		layout: nil,
 	}
 }

--- a/Window.go
+++ b/Window.go
@@ -143,7 +143,7 @@ func (w *WindowWidget) Layout(widgets ...Widget) {
 		}),
 	)
 
-	showed := imgui.BeginV(Context.FontAtlas.RegisterString(w.title), w.open, imgui.WindowFlags(w.flags))
+	showed := imgui.BeginV(Context.PrepareString(w.title), w.open, imgui.WindowFlags(w.flags))
 
 	if showed {
 		Layout(widgets).Build()

--- a/examples/paint/toolbar.go
+++ b/examples/paint/toolbar.go
@@ -110,7 +110,7 @@ func colorPopup(ce *color.RGBA, fe g.ColorEditFlags) {
 		refCol := pcol
 
 		if imgui.ColorPicker4V(
-			g.Context.FontAtlas.RegisterString("##COLOR_POPUP##me"),
+			"##COLOR_POPUP##me",
 			&col,
 			imgui.ColorEditFlags(fe),
 			utils.SliceToPtr(refCol),


### PR DESCRIPTION
since imgui 1.92, passing glyph ranges is no longer needed.

fix #1035 