### PR TITLE
Allow setting focus to InputText widget

### DIFF
--- a/TextWidgets.go
+++ b/TextWidgets.go
@@ -266,7 +266,7 @@ func (i *InputTextWidget) Build() {
 	if i.focus {
 		imgui.SetKeyboardFocusHere()
 	}
-	
+
 	isChanged := imgui.InputTextWithHint(i.label.String(), i.hint, i.value, imgui.InputTextFlags(i.flags), i.cb)
 
 	if isChanged && i.onChange != nil {

--- a/TextWidgets.go
+++ b/TextWidgets.go
@@ -171,6 +171,7 @@ type InputTextWidget struct {
 	flags      InputTextFlags
 	cb         imgui.InputTextCallback
 	onChange   func()
+	focus      bool
 }
 
 // InputText creates new input text widget.
@@ -183,6 +184,7 @@ func InputText(value *string) *InputTextWidget {
 		flags:    0,
 		cb:       nil,
 		onChange: nil,
+		focus:    false,
 	}
 }
 
@@ -240,6 +242,12 @@ func (i *InputTextWidget) OnChange(onChange func()) *InputTextWidget {
 	return i
 }
 
+// Focus sets if the field should have keyboard focus.
+func (i *InputTextWidget) Focus(focus bool) *InputTextWidget {
+	i.focus = focus
+	return i
+}
+
 // Build implements Widget interface.
 func (i *InputTextWidget) Build() {
 	// Get state
@@ -255,6 +263,10 @@ func (i *InputTextWidget) Build() {
 		defer PopItemWidth()
 	}
 
+	if i.focus {
+		imgui.SetKeyboardFocusHere()
+	}
+	
 	isChanged := imgui.InputTextWithHint(i.label.String(), i.hint, i.value, imgui.InputTextFlags(i.flags), i.cb)
 
 	if isChanged && i.onChange != nil {


### PR DESCRIPTION
Hello again,

I want to bring keyboard focus an InputText Widget.  
I tried setting the keyboard focus with a Custom Widget before the input, but it caused issues with the cursor position in my layouts.  

I found it would be easier to have the InputText Widget handle the focus instead of having to insert a Custom widget.  
Maybe other inputs could have the same feature, but I only needed this so I kept the scope short.  I can help add it to other widgets if keeping a consistent API between them is important.

Thanks for your feedback.