### PR TITLE
breaking(ContextMenu): rename MouseButton => Flags + change flags type

### DIFF
--- a/Flags.go
+++ b/Flags.go
@@ -270,10 +270,10 @@ type FocusedFlags imgui.FocusedFlags
 
 // focused flags list.
 const (
-	FocusedFlagsNone             = (imgui.FocusedFlagsNone)
-	FocusedFlagsChildWindows     = (imgui.FocusedFlagsChildWindows)   // Return true if any children of the window is focused
-	FocusedFlagsRootWindow       = (imgui.FocusedFlagsRootWindow)     // Test from root window (top most parent of the current hierarchy)
-	FocusedFlagsAnyWindow        = (imgui.FocusedFlagsAnyWindow)      // Return true if any window is focused. Important: If you are trying to tell how to dispatch your low-level inputs do NOT use this. Use 'io.WantCaptureMouse' instead! Please read the FAQ!
+	FocusedFlagsNone             = imgui.FocusedFlagsNone
+	FocusedFlagsChildWindows     = imgui.FocusedFlagsChildWindows     // Return true if any children of the window is focused
+	FocusedFlagsRootWindow       = imgui.FocusedFlagsRootWindow       // Test from root window (top most parent of the current hierarchy)
+	FocusedFlagsAnyWindow        = imgui.FocusedFlagsAnyWindow        // Return true if any window is focused. Important: If you are trying to tell how to dispatch your low-level inputs do NOT use this. Use 'io.WantCaptureMouse' instead! Please read the FAQ!
 	FocusedFlagsNoPopupHierarchy = imgui.FocusedFlagsNoPopupHierarchy // Do not consider popup hierarchy (do not treat popup emitter as parent of popup) (when used with ChildWindows or RootWindow)
 	// FocusedFlagsDockHierarchy               = 1 << 4   // Consider docking hierarchy (treat dockspace host as parent of docked window) (when used with ChildWindows or RootWindow).
 	FocusedFlagsRootAndChildWindows = imgui.FocusedFlagsRootAndChildWindows
@@ -530,4 +530,27 @@ const (
 	PlotScaleLog10 PlotScale = PlotScale(implot.ScaleLog10)
 	// PlotScaleSymLog is a symmetric log scale.
 	PlotScaleSymLog PlotScale = PlotScale(implot.ScaleSymLog)
+)
+
+type PopupFlags imgui.PopupFlags
+
+const (
+	PopupFlagsNone PopupFlags = PopupFlags(imgui.PopupFlagsNone)
+	// For BeginPopupContext*(): open on Left Mouse release. Only one button allowed!
+	PopupFlagsMouseButtonLeft PopupFlags = PopupFlags(imgui.PopupFlagsMouseButtonLeft)
+	// For BeginPopupContext*(): open on Right Mouse release. Only one button allowed! (default)
+	PopupFlagsMouseButtonRight PopupFlags = PopupFlags(imgui.PopupFlagsMouseButtonRight)
+	// For BeginPopupContext*(): open on Middle Mouse release. Only one button allowed!
+	PopupFlagsMouseButtonMiddle PopupFlags = PopupFlags(imgui.PopupFlagsMouseButtonMiddle)
+	// For OpenPopup*(), BeginPopupContext*(): don't reopen same popup if already open (won't reposition, won't reinitialize navigation)
+	PopupFlagsNoReopen PopupFlags = PopupFlags(imgui.PopupFlagsNoReopen)
+	// For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack
+	PopupFlagsNoOpenOverExistingPopup PopupFlags = PopupFlags(imgui.PopupFlagsNoOpenOverExistingPopup)
+	// For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space
+	PopupFlagsNoOpenOverItems PopupFlags = PopupFlags(imgui.PopupFlagsNoOpenOverItems)
+	// For IsPopupOpen(): ignore the ImGuiID parameter and test for any popup.
+	PopupFlagsAnyPopupId PopupFlags = PopupFlags(imgui.PopupFlagsAnyPopupId)
+	// For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level)
+	PopupFlagsAnyPopupLevel PopupFlags = PopupFlags(imgui.PopupFlagsAnyPopupLevel)
+	PopupFlagsAnyPopup      PopupFlags = PopupFlags(imgui.PopupFlagsAnyPopup)
 )

--- a/Flags.go
+++ b/Flags.go
@@ -532,25 +532,27 @@ const (
 	PlotScaleSymLog PlotScale = PlotScale(implot.ScaleSymLog)
 )
 
+// PopupFlags represents a flags for Popup, PopupModal and ContextMenu.
 type PopupFlags imgui.PopupFlags
 
+// A list of popup flags.
 const (
 	PopupFlagsNone PopupFlags = PopupFlags(imgui.PopupFlagsNone)
 	// For BeginPopupContext*(): open on Left Mouse release. Only one button allowed!
 	PopupFlagsMouseButtonLeft PopupFlags = PopupFlags(imgui.PopupFlagsMouseButtonLeft)
-	// For BeginPopupContext*(): open on Right Mouse release. Only one button allowed! (default)
+	// For BeginPopupContext*(): open on Right Mouse release. Only one button allowed! (default).
 	PopupFlagsMouseButtonRight PopupFlags = PopupFlags(imgui.PopupFlagsMouseButtonRight)
 	// For BeginPopupContext*(): open on Middle Mouse release. Only one button allowed!
 	PopupFlagsMouseButtonMiddle PopupFlags = PopupFlags(imgui.PopupFlagsMouseButtonMiddle)
-	// For OpenPopup*(), BeginPopupContext*(): don't reopen same popup if already open (won't reposition, won't reinitialize navigation)
+	// For OpenPopup*(), BeginPopupContext*(): don't reopen same popup if already open (won't reposition, won't reinitialize navigation).
 	PopupFlagsNoReopen PopupFlags = PopupFlags(imgui.PopupFlagsNoReopen)
-	// For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack
+	// For OpenPopup*(), BeginPopupContext*(): don't open if there's already a popup at the same level of the popup stack.
 	PopupFlagsNoOpenOverExistingPopup PopupFlags = PopupFlags(imgui.PopupFlagsNoOpenOverExistingPopup)
-	// For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space
+	// For BeginPopupContextWindow(): don't return true when hovering items, only when hovering empty space.
 	PopupFlagsNoOpenOverItems PopupFlags = PopupFlags(imgui.PopupFlagsNoOpenOverItems)
 	// For IsPopupOpen(): ignore the ImGuiID parameter and test for any popup.
-	PopupFlagsAnyPopupId PopupFlags = PopupFlags(imgui.PopupFlagsAnyPopupId)
-	// For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level)
+	PopupFlagsAnyPopupID PopupFlags = PopupFlags(imgui.PopupFlagsAnyPopupId)
+	// For IsPopupOpen(): search/test at any level of the popup stack (default test in the current level).
 	PopupFlagsAnyPopupLevel PopupFlags = PopupFlags(imgui.PopupFlagsAnyPopupLevel)
 	PopupFlagsAnyPopup      PopupFlags = PopupFlags(imgui.PopupFlagsAnyPopup)
 )

--- a/Widgets.go
+++ b/Widgets.go
@@ -318,7 +318,8 @@ func (c *ContextMenuWidget) Layout(widgets ...Widget) *ContextMenuWidget {
 	return c
 }
 
-// MouseButton sets mouse button that will trigger the context menu.
+// Flags sets popup flags, especially the mouse button that will trigger the context menu.
+// See PopupFlags for more details.
 func (c *ContextMenuWidget) Flags(f PopupFlags) *ContextMenuWidget {
 	c.flags = f
 	return c

--- a/Widgets.go
+++ b/Widgets.go
@@ -298,17 +298,17 @@ var _ Widget = &ContextMenuWidget{}
 
 // ContextMenuWidget is a context menu on another widget. (e.g. right-click menu on button).
 type ContextMenuWidget struct {
-	id          ID
-	mouseButton MouseButton
-	layout      Layout
+	id     ID
+	flags  PopupFlags
+	layout Layout
 }
 
 // ContextMenu creates new ContextMenuWidget.
 func ContextMenu() *ContextMenuWidget {
 	return &ContextMenuWidget{
-		mouseButton: MouseButtonRight,
-		layout:      nil,
-		id:          GenAutoID("ContextMenu"),
+		flags:  PopupFlagsMouseButtonRight,
+		layout: nil,
+		id:     GenAutoID("ContextMenu"),
 	}
 }
 
@@ -319,8 +319,8 @@ func (c *ContextMenuWidget) Layout(widgets ...Widget) *ContextMenuWidget {
 }
 
 // MouseButton sets mouse button that will trigger the context menu.
-func (c *ContextMenuWidget) MouseButton(mouseButton MouseButton) *ContextMenuWidget {
-	c.mouseButton = mouseButton
+func (c *ContextMenuWidget) Flags(f PopupFlags) *ContextMenuWidget {
+	c.flags = f
 	return c
 }
 
@@ -332,7 +332,7 @@ func (c *ContextMenuWidget) ID(id ID) *ContextMenuWidget {
 
 // Build implements Widget interface.
 func (c *ContextMenuWidget) Build() {
-	if imgui.BeginPopupContextItemV(c.id.String(), imgui.PopupFlags(c.mouseButton)) {
+	if imgui.BeginPopupContextItemV(c.id.String(), imgui.PopupFlags(c.flags)) {
 		c.layout.Build()
 		imgui.EndPopup()
 	}


### PR DESCRIPTION
Hi,
Generally `MouseButton` is not equal `PopupFlags` anymore. THis caused widgets example to crash.