### PR TITLE
Plot: rename [X,Y,]Lim{its => }

### DIFF
--- a/Plot.go
+++ b/Plot.go
@@ -201,7 +201,7 @@ func (p *PlotCanvasWidget) XLim(xmin, xmax float64, cond ExecCondition, axes ...
 	return p
 }
 
-// YLimits allows to set Y axis limits.
+// YLim allows to set Y axis limits.
 func (p *PlotCanvasWidget) YLim(ymin, ymax float64, cond ExecCondition, axes ...PlotYAxis) *PlotCanvasWidget {
 	if len(axes) == 0 {
 		axes = append(axes, AxisY1)

--- a/Plot.go
+++ b/Plot.go
@@ -183,13 +183,13 @@ func (p *PlotCanvasWidget) YLabel(label string, axes ...PlotYAxis) *PlotCanvasWi
 	return p
 }
 
-// Limits sets X and Y axis limits for the default axis (AxisX1 and AxisY1).
-func (p *PlotCanvasWidget) Limits(xmin, xmax, ymin, ymax float64, cond ExecCondition) *PlotCanvasWidget {
-	return p.XLimits(xmin, xmax, cond).YLimits(ymin, ymax, cond)
+// Lim sets X and Y axis limits for the default axis (AxisX1 and AxisY1).
+func (p *PlotCanvasWidget) Lim(xmin, xmax, ymin, ymax float64, cond ExecCondition) *PlotCanvasWidget {
+	return p.XLim(xmin, xmax, cond).YLim(ymin, ymax, cond)
 }
 
-// XLimits allows to set X axis limits.
-func (p *PlotCanvasWidget) XLimits(xmin, xmax float64, cond ExecCondition, axes ...PlotXAxis) *PlotCanvasWidget {
+// XLim allows to set X axis limits.
+func (p *PlotCanvasWidget) XLim(xmin, xmax float64, cond ExecCondition, axes ...PlotXAxis) *PlotCanvasWidget {
 	if len(axes) == 0 {
 		axes = append(axes, AxisX1)
 	}
@@ -202,7 +202,7 @@ func (p *PlotCanvasWidget) XLimits(xmin, xmax float64, cond ExecCondition, axes 
 }
 
 // YLimits allows to set Y axis limits.
-func (p *PlotCanvasWidget) YLimits(ymin, ymax float64, cond ExecCondition, axes ...PlotYAxis) *PlotCanvasWidget {
+func (p *PlotCanvasWidget) YLim(ymin, ymax float64, cond ExecCondition, axes ...PlotYAxis) *PlotCanvasWidget {
 	if len(axes) == 0 {
 		axes = append(axes, AxisY1)
 	}

--- a/examples/plot/main.go
+++ b/examples/plot/main.go
@@ -29,14 +29,14 @@ var (
 
 func loop() {
 	g.SingleWindow().Layout(
-		g.Plot("Plot").Limits(0, 100, -1.2, 1.2, g.ConditionOnce).
-			YLimits(-1.2, 1.2, g.ConditionOnce, g.AxisY1, g.AxisY2).Plots(
+		g.Plot("Plot").Lim(0, 100, -1.2, 1.2, g.ConditionOnce).
+			YLim(-1.2, 1.2, g.ConditionOnce, g.AxisY1, g.AxisY2).Plots(
 			g.Line("Line Plot", linedata),
 			g.Line("Line Plot 2", linedata2),
 			g.SwitchPlotAxes(g.AxisX1, g.AxisY2),
 			g.Scatter("Scatter", scatterdata),
 		).YLabel("secondary axis", g.AxisY2),
-		g.Plot("Plot (Time Scale on X Axis)").Limits(timeDataMin, timeDataMax, 0, 1, g.ConditionOnce).Plots(
+		g.Plot("Plot (Time Scale on X Axis)").Lim(timeDataMin, timeDataMax, 0, 1, g.ConditionOnce).Plots(
 			g.LineXY("Time Line", timeDataX, timeDataY),
 			g.ScatterXY("Time Scatter", timeDataX, timeScatterY),
 		).XScale(g.PlotScaleTime),
@@ -44,7 +44,7 @@ func loop() {
 			g.Style().To(
 				g.Plot("Plot Bars").
 					Size(500, 250).
-					Limits(0, 10, -1.2, 1.2, g.ConditionOnce).
+					Lim(0, 10, -1.2, 1.2, g.ConditionOnce).
 					Plots(
 						g.Bar("Plot Bar", bardata),
 						g.Bar("Plot Bar 2", bardata2).Shift(0.2),
@@ -57,7 +57,7 @@ func loop() {
 				Size(250, 250).
 				XFlags(g.PlotAxisFlagsNoDecorations).
 				YFlags(g.PlotAxisFlagsNoDecorations).
-				Limits(0, 1, 0, 1, g.ConditionAlways).
+				Lim(0, 1, 0, 1, g.ConditionAlways).
 				Plots(
 					// StyleSetter works also for plots
 					g.Style().Plots(


### PR DESCRIPTION
This change is meant to unify naming convention for the plots api.

In most languages, those methods are called *Lim (instead of Limits). Examples:
- matplotlib.pyplot https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.xlim.html
- R's ggplot2: https://www.rdocumentation.org/packages/ggplot2/versions/1.0.0/topics/xlim