### PR TITLE
fix: broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,4 +301,4 @@ All kinds of pull requests (document, demo, screenshots, code, etc.) are more th
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AllenDang/giu&type=Date)](https://star-history.com/#AllenDang/giu&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AllenDang/giu&type=Date)](https://star-history.dera.page/#AllenDang/giu&Date)


### PR DESCRIPTION
The star history chart in the README no longer renders because its data source is broken. This change points it to a working endpoint so the chart displays correctly again.